### PR TITLE
143 allow relative paths in runconfig and processconfig

### DIFF
--- a/pytrnsys/psim/processParallelTrnsys.py
+++ b/pytrnsys/psim/processParallelTrnsys.py
@@ -182,7 +182,6 @@ class ProcessParallelTrnsys:
         self.configPath = path
         tool = readConfig.ReadConfigTrnsys()
         tool.readFile(path, name, self.inputs, parseFileCreated=parseFileCreated)
-        self.inputs["pathBase"] = path
         self.logger.setLevel(self.inputs["outputLevel"])
         if "latexNames" in self.inputs.keys():
             if ":" not in self.inputs["latexNames"]:

--- a/pytrnsys/psim/processParallelTrnsys.py
+++ b/pytrnsys/psim/processParallelTrnsys.py
@@ -129,7 +129,7 @@ class ProcessParallelTrnsys:
 
         self.logger = log.getOrCreateCustomLogger("root", self.inputs["outputLevel"])
 
-    def defaultInputs(self):
+    def defaultInputs(self, pathBase=None):
 
         self.inputs = {}
         self.inputs["plotStyle"] = "line"
@@ -147,7 +147,10 @@ class ProcessParallelTrnsys:
         self.inputs[
             "forceProcess"
         ] = True  # even if results file exist it proceess the results, otherwise it checks if it exists
-        self.inputs["pathBase"] = os.getcwd()
+        if pathBase:
+            self.inputs["pathBase"] = pathBase
+        else:
+            self.inputs["pathBase"] = os.getcwd()
         self.inputs["setPrintDataForGle"] = True
         self.inputs["firstConsideredTime"] = None  # Be carefull here. Thsi will not be proprly filtered
         self.inputs["buildingArea"] = 1072.0
@@ -179,6 +182,7 @@ class ProcessParallelTrnsys:
         self.configPath = path
         tool = readConfig.ReadConfigTrnsys()
         tool.readFile(path, name, self.inputs, parseFileCreated=parseFileCreated)
+        self.inputs["pathBase"] = path
         self.logger.setLevel(self.inputs["outputLevel"])
         if "latexNames" in self.inputs.keys():
             if ":" not in self.inputs["latexNames"]:

--- a/pytrnsys/trnsys_util/readConfigTrnsys.py
+++ b/pytrnsys/trnsys_util/readConfigTrnsys.py
@@ -49,7 +49,8 @@ class ReadConfigTrnsys:
     def __init__(self):
         pass
 
-    def str2bool(self, v):
+    @staticmethod
+    def str2bool(v):
         return v.lower() in ("yes", "true", "t", "1")
 
     def readFile(self, path, name, inputs, parseFileCreated=True, controlDataType=True):

--- a/pytrnsys/trnsys_util/readConfigTrnsys.py
+++ b/pytrnsys/trnsys_util/readConfigTrnsys.py
@@ -211,8 +211,8 @@ class ReadConfigTrnsys:
                 else:
                     pass
 
-        lines, inputs = self._addMissingDefaultPaths(addPathBase, addPathToConnectionInfo, addProjectPath, addProjects, inputs, lines,
-                                     name, path)
+        lines, inputs = self._addMissingDefaultPaths(addPathBase, addPathToConnectionInfo, addProjectPath, addProjects,
+                                                     inputs, lines, name, path)
 
         return lines
 

--- a/pytrnsys/trnsys_util/readConfigTrnsys.py
+++ b/pytrnsys/trnsys_util/readConfigTrnsys.py
@@ -58,79 +58,36 @@ class ReadConfigTrnsys:
         lines = processFiles.purgueLines(lines, skypChar, None, removeBlankLines=True, removeBlankSpaces=False)
         lines = processFiles.purgueComments(lines, skypChar)
 
-        if "calcMonthly" not in inputs:
-            inputs["calcMonthly"] = []
-
-        if "calcMonthlyTest" not in inputs:
-            inputs["calcMonthlyTest"] = []
-
-        if "calcMonthlyMax" not in inputs:
-            inputs["calcMonthlyMax"] = []
-
-        if "calcMonthlyMin" not in inputs:
-            inputs["calcMonthlyMin"] = []
-
-        if "calcHourly" not in inputs:
-            inputs["calcHourly"] = []
-
-        if "calcMonthlyFromHourly" not in inputs:
-            inputs["calcMonthlyFromHourly"] = []
-
-        if "calcDaily" not in inputs:
-            inputs["calcDaily"] = []
-
-        if "calc" not in inputs:
-            inputs["calc"] = []
-
-        if "calcTest" not in inputs:
-            inputs["calcTest"] = []
-
-        if "calcCumSumHourly" not in inputs:
-            inputs["calcCumSumHourly"] = []
-
-        if "calcHourlyTest" not in inputs:  # dirty trick to calculate after calcCumSumHourly DC
-            inputs["calcHourlyTest"] = []
-
-        if "calcTimeStep" not in inputs:
-            inputs["calcTimeStep"] = []
-
-        if "calcTimeStepTest" not in inputs:
-            inputs["calcTimeStepTest"] = []
-
-        if "calcCumSumTimeStep" not in inputs:
-            inputs["calcCumSumTimeStep"] = []
+        inputs = self._addMissingFields(inputs)
 
         if parseFileCreated:
-            parsedFile = "%s.parse.dat" % configFile
-            outfile = open(parsedFile, "w")
-            outfile.writelines(lines)
-            outfile.close()
+            self._createParseFile(configFile, lines)
 
         addPathToConnectionInfo = True
         addProjects = True
         addProjectPath = True
         addPathBase = True
 
-        for i in range(len(lines)):
-            # todo: use enumerate
+        for i, line in enumerate(lines):
 
-            if lines[i][-1:] == "\n":
-                lines[i] = lines[i][0:-1]
+            if line[-1:] == "\n":
+                line = line[0:-1]
+                lines[i] = line
 
-            splitLine = lines[i].split()
+            splitLine = line.split()
 
             if splitLine[0] == "bool":
                 inputs[splitLine[1]] = self.str2bool(splitLine[2])
             elif splitLine[0] == "int":
                 inputs[splitLine[1]] = int(splitLine[2])
             elif splitLine[0] == "string":
-                if 'string pathToConnectionInfo ' in lines[i]:
+                if 'string pathToConnectionInfo ' in line:
                     addPathToConnectionInfo = False
-                if 'string PROJECT$ ' in lines[i]:
+                if 'string PROJECT$ ' in line:
                     addProjects = False
-                if 'string projectPath ' in lines[i]:
+                if 'string projectPath ' in line:
                     addProjectPath = False
-                if 'string pathBase ' in lines[i]:
+                if 'string pathBase ' in line:
                     addPathBase = False
 
                 if len(splitLine) != 3:
@@ -217,6 +174,46 @@ class ReadConfigTrnsys:
         return lines
 
     @staticmethod
+    def _createParseFile(configFile, lines):
+        parsedFile = "%s.parse.dat" % configFile
+        outfile = open(parsedFile, "w")
+        outfile.writelines(lines)
+        outfile.close()
+
+    @staticmethod
+    def _addMissingFields(inputs):
+        if "calcMonthly" not in inputs:
+            inputs["calcMonthly"] = []
+        if "calcMonthlyTest" not in inputs:
+            inputs["calcMonthlyTest"] = []
+        if "calcMonthlyMax" not in inputs:
+            inputs["calcMonthlyMax"] = []
+        if "calcMonthlyMin" not in inputs:
+            inputs["calcMonthlyMin"] = []
+        if "calcHourly" not in inputs:
+            inputs["calcHourly"] = []
+        if "calcMonthlyFromHourly" not in inputs:
+            inputs["calcMonthlyFromHourly"] = []
+        if "calcDaily" not in inputs:
+            inputs["calcDaily"] = []
+        if "calc" not in inputs:
+            inputs["calc"] = []
+        if "calcTest" not in inputs:
+            inputs["calcTest"] = []
+        if "calcCumSumHourly" not in inputs:
+            inputs["calcCumSumHourly"] = []
+        if "calcHourlyTest" not in inputs:  # dirty trick to calculate after calcCumSumHourly DC
+            inputs["calcHourlyTest"] = []
+        if "calcTimeStep" not in inputs:
+            inputs["calcTimeStep"] = []
+        if "calcTimeStepTest" not in inputs:
+            inputs["calcTimeStepTest"] = []
+        if "calcCumSumTimeStep" not in inputs:
+            inputs["calcCumSumTimeStep"] = []
+
+        return inputs
+
+    @staticmethod
     def _addMissingDefaultPaths(addPathBase, addPathToConnectionInfo, addProjectPath, addProjects, inputs, lines,
                                 name, path):
         if "run.config" in name:
@@ -232,9 +229,8 @@ class ReadConfigTrnsys:
                 inputs["projectPath"] = path
                 lines.append('string projectPath ' + str(path))
 
-        elif "process.config" in name:
-            if addPathBase:
-                inputs["pathBase"] = path
-                lines.append("string pathBase " + str(path))
+        elif "process.config" in name and addPathBase:
+            inputs["pathBase"] = path
+            lines.append("string pathBase " + str(path))
 
         return lines, inputs

--- a/pytrnsys/trnsys_util/readConfigTrnsys.py
+++ b/pytrnsys/trnsys_util/readConfigTrnsys.py
@@ -63,6 +63,12 @@ class ReadConfigTrnsys:
         lines = processFiles.purgueLines(lines, skypChar, None, removeBlankLines=True, removeBlankSpaces=False)
         lines = processFiles.purgueComments(lines, skypChar)
 
+        if name == "run.config":
+            # This should allow this info to be removed from the run.config file.
+            inputs["pathToConnectionInfo"] = os.path.join(path, "DdckPlaceHolderValues.json")
+            inputs["PROJECT$"] = os.path.join(path, "ddck")
+            inputs["projectPath"] = path
+
         if "calcMonthly" not in inputs:
             inputs["calcMonthly"] = []
 

--- a/tests/pytrnsys/trnsys_util/__init__.py
+++ b/tests/pytrnsys/trnsys_util/__init__.py
@@ -1,0 +1,2 @@
+# pylint: skip-file
+# type: ignore

--- a/tests/pytrnsys/trnsys_util/data/process.config_with_absolute_paths
+++ b/tests/pytrnsys/trnsys_util/data/process.config_with_absolute_paths
@@ -1,0 +1,48 @@
+# Overall processing variables
+bool processParallel False
+bool processQvsT False
+#bool maxMinAvoided False
+bool cleanModeLatex False
+bool forceProcess  True #even if results file exist it proceess the results, otherwise it checks if it exists
+bool setPrintDataForGle True
+bool isTrnsys True
+int reduceCpu 1
+string outputLevel "DEBUG"
+
+bool createLatexPdf True
+bool calculateHeatDemand True
+# bool dailyBalance True
+
+# Sorting the results (so far only one year can be analysed and displayed)
+int yearReadedInMonthlyFile -1
+int firstMonthUsed 0 # 6     # 0=January 1=February 6=July 7=August
+int numberOfYearsInHourlyFile 1 #20
+
+# Paths
+string latexNames "latexNames.json"
+string pathBase "C:\Users\epic.user\EpicSimulation"
+string dllTrnsysPath "C:\Trnsys18\UserLib\ReleaseDlls"
+
+# Calculations of monthly values
+# calcMonthly hpSPF = (Pdhw_kW+qSysOut_BuiDemand)/ElHpTot_kW
+
+# Calculations of scalar values
+# calc Q_SH = PheatBui_kW_Tot
+# calc Q_DHW = Pdhw_kW_Tot
+# calc Q_yearly = Pdhw_kW_Tot + PheatBui_kW_Tot
+# calc E_yearly = elSysIn_Q_HpComp_Tot
+# calc E_PV = elSysIn_PV_Tot
+# calc VTes = Vol_Tes1
+# calc SPF = (Pdhw_kW_Tot+qSysOut_BuiDemand_Tot)/ElHpTot_kW_Tot
+
+
+# Additional content of the pdf
+#stringArray caseDefinition "Vol_Tes1" "Vol_Tes2"
+#stringArray monthlyBalance "PelPVRoof_kW" "-PvToBat_kW" "-PvToHeatSys_kW" "-PvToHH_kW" "-PvToGrid_kW"
+stringArray plotHourly "TInQSrc1"
+
+########## results file array #############
+#stringArray results "sizeHpNom"  "MfrHpCondNom"  "START"  "STOP" "SPF" "altid" "lGhxProbes"  #values to be printed to json
+#stringArray plotTimestepQvsT "PRdIn_kW" "TRdFl" "PRdIn_kW" "TRdRt" "QHpCond_kW" "THpCondOut" "QHpEvap_kW" "ThpEvapIn" "Pdhw_kW" "TPiDHWDemand" "QHpDes_kW" "THpDesOut" "PPiCircLoss_kW" "TLoadDHWHXIn" "PPiCircLoss_kW" "TLoadDHWHXOut" "Qghx_kW" "TGHXout"
+#stringArray QvsTnormalized "PRdIn_kW" "Pdhw_kW" "PPiCircLoss_kW" # this line is needed for definition of the heat to which the plot should be normalized!
+#stringArray comparePlot "lGhxProbes" "SPF" "altid"

--- a/tests/pytrnsys/trnsys_util/data/process.config_without_paths
+++ b/tests/pytrnsys/trnsys_util/data/process.config_without_paths
@@ -1,0 +1,47 @@
+# Overall processing variables
+bool processParallel False
+bool processQvsT False
+#bool maxMinAvoided False
+bool cleanModeLatex False
+bool forceProcess  True #even if results file exist it proceess the results, otherwise it checks if it exists
+bool setPrintDataForGle True
+bool isTrnsys True
+int reduceCpu 1
+string outputLevel "DEBUG"
+
+bool createLatexPdf True
+bool calculateHeatDemand True
+# bool dailyBalance True
+
+# Sorting the results (so far only one year can be analysed and displayed)
+int yearReadedInMonthlyFile -1
+int firstMonthUsed 0 # 6     # 0=January 1=February 6=July 7=August
+int numberOfYearsInHourlyFile 1 #20
+
+# Paths
+string latexNames "latexNames.json"
+string dllTrnsysPath "C:\Trnsys18\UserLib\ReleaseDlls"
+
+# Calculations of monthly values
+# calcMonthly hpSPF = (Pdhw_kW+qSysOut_BuiDemand)/ElHpTot_kW
+
+# Calculations of scalar values
+# calc Q_SH = PheatBui_kW_Tot
+# calc Q_DHW = Pdhw_kW_Tot
+# calc Q_yearly = Pdhw_kW_Tot + PheatBui_kW_Tot
+# calc E_yearly = elSysIn_Q_HpComp_Tot
+# calc E_PV = elSysIn_PV_Tot
+# calc VTes = Vol_Tes1
+# calc SPF = (Pdhw_kW_Tot+qSysOut_BuiDemand_Tot)/ElHpTot_kW_Tot
+
+
+# Additional content of the pdf
+#stringArray caseDefinition "Vol_Tes1" "Vol_Tes2"
+#stringArray monthlyBalance "PelPVRoof_kW" "-PvToBat_kW" "-PvToHeatSys_kW" "-PvToHH_kW" "-PvToGrid_kW"
+stringArray plotHourly "TInQSrc1"
+
+########## results file array #############
+#stringArray results "sizeHpNom"  "MfrHpCondNom"  "START"  "STOP" "SPF" "altid" "lGhxProbes"  #values to be printed to json
+#stringArray plotTimestepQvsT "PRdIn_kW" "TRdFl" "PRdIn_kW" "TRdRt" "QHpCond_kW" "THpCondOut" "QHpEvap_kW" "ThpEvapIn" "Pdhw_kW" "TPiDHWDemand" "QHpDes_kW" "THpDesOut" "PPiCircLoss_kW" "TLoadDHWHXIn" "PPiCircLoss_kW" "TLoadDHWHXOut" "Qghx_kW" "TGHXout"
+#stringArray QvsTnormalized "PRdIn_kW" "Pdhw_kW" "PPiCircLoss_kW" # this line is needed for definition of the heat to which the plot should be normalized!
+#stringArray comparePlot "lGhxProbes" "SPF" "altid"

--- a/tests/pytrnsys/trnsys_util/data/run.config_with_absolute_paths
+++ b/tests/pytrnsys/trnsys_util/data/run.config_with_absolute_paths
@@ -1,0 +1,42 @@
+############# GENERIC##############################
+
+bool ignoreOnlinePlotter  True
+int reduceCpu  4
+bool parseFileCreated True
+bool runCases True
+bool checkDeck True
+string outputLevel "INFO"
+string pathToConnectionInfo "C:\Users\epic.user\EpicSimulation\DdckPlaceHolderValues.json"
+
+############# AUTOMATIC WORK BOOL##############################
+
+bool doAutoUnitNumbering True
+bool generateUnitTypesUsed True
+bool addAutomaticEnergyBalance True
+
+#############PATHS################################
+
+string PROJECT$ "C:\Users\epic.user\EpicSimulation\ddck"
+string trnsysExePath "C:\Trnsys18\Exe\TRNExe.exe"
+
+################SCALING#########################
+
+string scaling "False" #"toDemand"
+string projectPath "C:\Users\epic.user\EpicSimulation"
+string nameRef "DoublePipeDebug"
+string runType "runFromConfig"
+
+#############FIXED CHANGED IN DDCK##################
+
+deck START 0    # 0 is midnight new year
+deck STOP  8760 # 8760 for a year
+deck dtSim 1    # time step in hours
+
+#############USED DDCKs##################
+
+PROJECT$ generic\head
+PROJECT$ control\hydraulic_control
+PROJECT$ hydraulic\hydraulic
+PROJECT$ QSrc1\QSrc
+PROJECT$ generic\end
+

--- a/tests/pytrnsys/trnsys_util/data/run.config_without_any_paths
+++ b/tests/pytrnsys/trnsys_util/data/run.config_without_any_paths
@@ -1,0 +1,39 @@
+############# GENERIC##############################
+
+bool ignoreOnlinePlotter  True
+int reduceCpu  4
+bool parseFileCreated True
+bool runCases True
+bool checkDeck True
+string outputLevel "INFO"
+
+############# AUTOMATIC WORK BOOL##############################
+
+bool doAutoUnitNumbering True
+bool generateUnitTypesUsed True
+bool addAutomaticEnergyBalance True
+
+#############PATHS################################
+
+string trnsysExePath "C:\Trnsys18\Exe\TRNExe.exe"
+
+################SCALING#########################
+
+string scaling "False" #"toDemand"
+string nameRef "DoublePipeDebug"
+string runType "runFromConfig"
+
+#############FIXED CHANGED IN DDCK##################
+
+deck START 0    # 0 is midnight new year
+deck STOP  8760 # 8760 for a year
+deck dtSim 1    # time step in hours
+
+#############USED DDCKs##################
+
+PROJECT$ generic\head
+PROJECT$ control\hydraulic_control
+PROJECT$ hydraulic\hydraulic
+PROJECT$ QSrc1\QSrc
+PROJECT$ generic\end
+

--- a/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
+++ b/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
@@ -1,5 +1,6 @@
 import pathlib as _pl
 import pytest as _pt
+import os as _os
 
 import pytrnsys.trnsys_util.readConfigTrnsys as _rct
 
@@ -39,9 +40,9 @@ def _getLines(path=None, without=False):
               'PROJECT$ generic\\end']
     if without:
         lines += ['string pathToConnectionInfo '
-                  f'{path}\\DdckPlaceHolderValues.json',
+                  f'{_os.path.join(path, "DdckPlaceHolderValues.json")}',
                   'string PROJECT$ '
-                  f'{path}\\ddck',
+                  f'{_os.path.join(path, "ddck")}',
                   'string projectPath '
                   f'{path}']
     return lines
@@ -114,8 +115,8 @@ def _getInputs(path=None, without=False, configType='run'):
         inputs['scaling'] = 'False'
         inputs['trnsysExePath'] = 'C:\\Trnsys18\\Exe\\TRNExe.exe'
         if without:
-            inputs['PROJECT$'] = f'{path}\\ddck'
-            inputs['pathToConnectionInfo'] = f'{path}\\DdckPlaceHolderValues.json'
+            inputs['PROJECT$'] = f'{_os.path.join(path, "ddck")}'
+            inputs['pathToConnectionInfo'] = f'{_os.path.join(path, "DdckPlaceHolderValues.json")}'
             inputs['projectPath'] = _pl.Path(f'{path}')
 
     elif configType == 'process':

--- a/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
+++ b/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
@@ -7,27 +7,27 @@ _DATA_DIR_PATH = _pl.Path(__file__).parent / "data"
 
 
 def _getLines(path=None, without=False):
-    LINES = ['bool ignoreOnlinePlotter  True',
+    lines = ['bool ignoreOnlinePlotter  True',
              'int reduceCpu  4',
              'bool parseFileCreated True',
              'bool runCases True',
              'bool checkDeck True',
              'string outputLevel "INFO"', ]
     if not without:
-        LINES += ['string pathToConnectionInfo '
+        lines += ['string pathToConnectionInfo '
                   '"C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json"', ]  # this one
-    LINES += ['bool doAutoUnitNumbering True',
+    lines += ['bool doAutoUnitNumbering True',
               'bool generateUnitTypesUsed True',
               'bool addAutomaticEnergyBalance True', ]
     if not without:
-        LINES += ['string PROJECT$ '
+        lines += ['string PROJECT$ '
                   '"C:\\Users\\epic.user\\EpicSimulation\\ddck"', ]
-    LINES += ['string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
+    lines += ['string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
               'string scaling "False"', ]
     if not without:
-        LINES += ['string projectPath '
+        lines += ['string projectPath '
                   '"C:\\Users\\epic.user\\EpicSimulation"', ]
-    LINES += ['string nameRef "DoublePipeDebug"',
+    lines += ['string nameRef "DoublePipeDebug"',
               'string runType "runFromConfig"',
               'deck START 0',
               'deck STOP  8760',
@@ -38,13 +38,13 @@ def _getLines(path=None, without=False):
               'PROJECT$ QSrc1\\QSrc',
               'PROJECT$ generic\\end']
     if without:
-        LINES += ['string pathToConnectionInfo '
+        lines += ['string pathToConnectionInfo '
                   f'{path}\\DdckPlaceHolderValues.json',
                   'string PROJECT$ '
                   f'{path}\\ddck',
                   'string projectPath '
                   f'{path}']
-    return LINES
+    return lines
 
 
 _ORIGINAL_LINES = _getLines()
@@ -52,7 +52,7 @@ _LINES_WITHOUT = _getLines(_DATA_DIR_PATH, without=True)
 
 
 def _getProcessLines(path=None, without=False):
-    LINES = ['bool processParallel False',
+    lines = ['bool processParallel False',
              'bool processQvsT False',
              'bool cleanModeLatex False',
              'bool forceProcess  True',
@@ -67,13 +67,13 @@ def _getProcessLines(path=None, without=False):
              'int numberOfYearsInHourlyFile 1',
              'string latexNames "latexNames.json"', ]
     if not without:
-        LINES += ['string pathBase "C:\\Users\\epic.user\\EpicSimulation"', ]
-    LINES += ['string dllTrnsysPath "C:\\Trnsys18\\UserLib\\ReleaseDlls"',
+        lines += ['string pathBase "C:\\Users\\epic.user\\EpicSimulation"', ]
+    lines += ['string dllTrnsysPath "C:\\Trnsys18\\UserLib\\ReleaseDlls"',
               'stringArray plotHourly "TInQSrc1"']
     if without:
-        LINES += ['string pathBase '
+        lines += ['string pathBase '
                   f'{path}']
-    return LINES
+    return lines
 
 
 _PROCESS_ORIGINAL_LINES = _getProcessLines()

--- a/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
+++ b/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
@@ -3,226 +3,149 @@ import pytest as _pt
 
 import pytrnsys.trnsys_util.readConfigTrnsys as _rct
 
-DATA_DIR_PATH = _pl.Path(__file__).parent / "data"
+_DATA_DIR_PATH = _pl.Path(__file__).parent / "data"
 
-ORIGINAL_LINES = ['bool ignoreOnlinePlotter  True',
-                  'int reduceCpu  4',
-                  'bool parseFileCreated True',
-                  'bool runCases True',
-                  'bool checkDeck True',
-                  'string outputLevel "INFO"',
-                  'string pathToConnectionInfo '
-                  '"C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json"',
-                  'bool doAutoUnitNumbering True',
-                  'bool generateUnitTypesUsed True',
-                  'bool addAutomaticEnergyBalance True',
-                  'string PROJECT$ '
-                  '"C:\\Users\\epic.user\\EpicSimulation\\ddck"',
-                  'string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
-                  'string scaling "False"',
-                  'string projectPath '
-                  '"C:\\Users\\epic.user\\EpicSimulation"',
-                  'string nameRef "DoublePipeDebug"',
-                  'string runType "runFromConfig"',
-                  'deck START 0',
-                  'deck STOP  8760',
-                  'deck dtSim 1',
-                  'PROJECT$ generic\\head',
-                  'PROJECT$ control\\hydraulic_control',
-                  'PROJECT$ hydraulic\\hydraulic',
-                  'PROJECT$ QSrc1\\QSrc',
-                  'PROJECT$ generic\\end']
 
-LINES_WITHOUT = ['bool ignoreOnlinePlotter  True',
-                 'int reduceCpu  4',
-                 'bool parseFileCreated True',
-                 'bool runCases True',
-                 'bool checkDeck True',
-                 'string outputLevel "INFO"',
-                 'bool doAutoUnitNumbering True',
-                 'bool generateUnitTypesUsed True',
-                 'bool addAutomaticEnergyBalance True',
-                 'string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
-                 'string scaling "False"',
-                 'string nameRef "DoublePipeDebug"',
-                 'string runType "runFromConfig"',
-                 'deck START 0',
-                 'deck STOP  8760',
-                 'deck dtSim 1',
-                 'PROJECT$ generic\\head',
-                 'PROJECT$ control\\hydraulic_control',
-                 'PROJECT$ hydraulic\\hydraulic',
-                 'PROJECT$ QSrc1\\QSrc',
-                 'PROJECT$ generic\\end',
-                 'string pathToConnectionInfo '
-                 f'{DATA_DIR_PATH}\\DdckPlaceHolderValues.json',
-                 'string PROJECT$ '
-                 f'{DATA_DIR_PATH}\\ddck',
-                 'string projectPath '
-                 f'{DATA_DIR_PATH}']
+def _getLines(_PATH=None, _without=False):
+    _LINES = ['bool ignoreOnlinePlotter  True',
+              'int reduceCpu  4',
+              'bool parseFileCreated True',
+              'bool runCases True',
+              'bool checkDeck True',
+              'string outputLevel "INFO"', ]
+    if not _without:
+        _LINES += ['string pathToConnectionInfo '
+                   '"C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json"', ]  # this one
+    _LINES += ['bool doAutoUnitNumbering True',
+               'bool generateUnitTypesUsed True',
+               'bool addAutomaticEnergyBalance True', ]
+    if not _without:
+        _LINES += ['string PROJECT$ '
+                   '"C:\\Users\\epic.user\\EpicSimulation\\ddck"', ]
+    _LINES += ['string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
+               'string scaling "False"', ]
+    if not _without:
+        _LINES += ['string projectPath '
+                   '"C:\\Users\\epic.user\\EpicSimulation"', ]
+    _LINES += ['string nameRef "DoublePipeDebug"',
+               'string runType "runFromConfig"',
+               'deck START 0',
+               'deck STOP  8760',
+               'deck dtSim 1',
+               'PROJECT$ generic\\head',
+               'PROJECT$ control\\hydraulic_control',
+               'PROJECT$ hydraulic\\hydraulic',
+               'PROJECT$ QSrc1\\QSrc',
+               'PROJECT$ generic\\end']
+    if _without:
+        _LINES += ['string pathToConnectionInfo '
+                   f'{_PATH}\\DdckPlaceHolderValues.json',
+                   'string PROJECT$ '
+                   f'{_PATH}\\ddck',
+                   'string projectPath '
+                   f'{_PATH}']
+    return _LINES
 
-PROCESS_ORIGINAL_LINES = ['bool processParallel False',
-                          'bool processQvsT False',
-                          'bool cleanModeLatex False',
-                          'bool forceProcess  True',
-                          'bool setPrintDataForGle True',
-                          'bool isTrnsys True',
-                          'int reduceCpu 1',
-                          'string outputLevel "DEBUG"',
-                          'bool createLatexPdf True',
-                          'bool calculateHeatDemand True',
-                          'int yearReadedInMonthlyFile -1',
-                          'int firstMonthUsed 0',
-                          'int numberOfYearsInHourlyFile 1',
-                          'string latexNames "latexNames.json"',
-                          'string pathBase "C:\\Users\\epic.user\\EpicSimulation"',
-                          'string dllTrnsysPath "C:\\Trnsys18\\UserLib\\ReleaseDlls"',
-                          'stringArray plotHourly "TInQSrc1"']
 
-PROCESS_LINES_WITHOUT = ['bool processParallel False',
-                         'bool processQvsT False',
-                         'bool cleanModeLatex False',
-                         'bool forceProcess  True',
-                         'bool setPrintDataForGle True',
-                         'bool isTrnsys True',
-                         'int reduceCpu 1',
-                         'string outputLevel "DEBUG"',
-                         'bool createLatexPdf True',
-                         'bool calculateHeatDemand True',
-                         'int yearReadedInMonthlyFile -1',
-                         'int firstMonthUsed 0',
-                         'int numberOfYearsInHourlyFile 1',
-                         'string latexNames "latexNames.json"',
-                         'string dllTrnsysPath "C:\\Trnsys18\\UserLib\\ReleaseDlls"',
-                         'stringArray plotHourly "TInQSrc1"',
-                         'string pathBase '
-                         f'{DATA_DIR_PATH}']
+_ORIGINAL_LINES = _getLines()
+_LINES_WITHOUT = _getLines(_DATA_DIR_PATH, _without=True)
 
-ORIGINAL_INPUTS = {'PROJECT$': 'C:\\Users\\epic.user\\EpicSimulation\\ddck',
-                   'addAutomaticEnergyBalance': True,
-                   'calc': [],
-                   'calcCumSumHourly': [],
-                   'calcCumSumTimeStep': [],
-                   'calcDaily': [],
-                   'calcHourly': [],
-                   'calcHourlyTest': [],
-                   'calcMonthly': [],
-                   'calcMonthlyFromHourly': [],
-                   'calcMonthlyMax': [],
-                   'calcMonthlyMin': [],
-                   'calcMonthlyTest': [],
-                   'calcTest': [],
-                   'calcTimeStep': [],
-                   'calcTimeStepTest': [],
-                   'checkDeck': True,
-                   'doAutoUnitNumbering': True,
-                   'generateUnitTypesUsed': True,
-                   'ignoreOnlinePlotter': True,
-                   'nameRef': 'DoublePipeDebug',
-                   'outputLevel': 'INFO',
-                   'parseFileCreated': True,
-                   'pathToConnectionInfo': 'C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json',
-                   'projectPath': 'C:\\Users\\epic.user\\EpicSimulation',
-                   'reduceCpu': 4,
-                   'runCases': True,
-                   'runType': 'runFromConfig',
-                   'scaling': 'False',
-                   'trnsysExePath': 'C:\\Trnsys18\\Exe\\TRNExe.exe'}
 
-INPUTS_WITHOUT = {'PROJECT$': f'{DATA_DIR_PATH}\\ddck',
-                  'addAutomaticEnergyBalance': True,
-                  'calc': [],
-                  'calcCumSumHourly': [],
-                  'calcCumSumTimeStep': [],
-                  'calcDaily': [],
-                  'calcHourly': [],
-                  'calcHourlyTest': [],
-                  'calcMonthly': [],
-                  'calcMonthlyFromHourly': [],
-                  'calcMonthlyMax': [],
-                  'calcMonthlyMin': [],
-                  'calcMonthlyTest': [],
-                  'calcTest': [],
-                  'calcTimeStep': [],
-                  'calcTimeStepTest': [],
-                  'checkDeck': True,
-                  'doAutoUnitNumbering': True,
-                  'generateUnitTypesUsed': True,
-                  'ignoreOnlinePlotter': True,
-                  'nameRef': 'DoublePipeDebug',
-                  'outputLevel': 'INFO',
-                  'parseFileCreated': True,
-                  'pathToConnectionInfo': f'{DATA_DIR_PATH}\\DdckPlaceHolderValues.json',
-                  'projectPath': _pl.WindowsPath(f'{DATA_DIR_PATH}'),
-                  'reduceCpu': 4,
-                  'runCases': True,
-                  'runType': 'runFromConfig',
-                  'scaling': 'False',
-                  'trnsysExePath': 'C:\\Trnsys18\\Exe\\TRNExe.exe'}
+def _getProcessLines(_PATH=None, _without=False):
+    _LINES = ['bool processParallel False',
+              'bool processQvsT False',
+              'bool cleanModeLatex False',
+              'bool forceProcess  True',
+              'bool setPrintDataForGle True',
+              'bool isTrnsys True',
+              'int reduceCpu 1',
+              'string outputLevel "DEBUG"',
+              'bool createLatexPdf True',
+              'bool calculateHeatDemand True',
+              'int yearReadedInMonthlyFile -1',
+              'int firstMonthUsed 0',
+              'int numberOfYearsInHourlyFile 1',
+              'string latexNames "latexNames.json"', ]
+    if not _without:
+        _LINES += ['string pathBase "C:\\Users\\epic.user\\EpicSimulation"', ]
+    _LINES += ['string dllTrnsysPath "C:\\Trnsys18\\UserLib\\ReleaseDlls"',
+               'stringArray plotHourly "TInQSrc1"']
+    if _without:
+        _LINES += ['string pathBase '
+                   f'{_DATA_DIR_PATH}']
+    return _LINES
 
-INPUTS_PROCESS = {'calc': [],
-                  'calcCumSumHourly': [],
-                  'calcCumSumTimeStep': [],
-                  'calcDaily': [],
-                  'calcHourly': [],
-                  'calcHourlyTest': [],
-                  'calcMonthly': [],
-                  'calcMonthlyFromHourly': [],
-                  'calcMonthlyMax': [],
-                  'calcMonthlyMin': [],
-                  'calcMonthlyTest': [],
-                  'calcTest': [],
-                  'calcTimeStep': [],
-                  'calcTimeStepTest': [],
-                  'calculateHeatDemand': True,
-                  'cleanModeLatex': False,
-                  'createLatexPdf': True,
-                  'dllTrnsysPath': 'C:\\Trnsys18\\UserLib\\ReleaseDlls',
-                  'firstMonthUsed': 0,
-                  'forceProcess': True,
-                  'isTrnsys': True,
-                  'latexNames': 'latexNames.json',
-                  'numberOfYearsInHourlyFile': 1,
-                  'outputLevel': 'DEBUG',
-                  'pathBase': 'C:\\Users\\epic.user\\EpicSimulation',
-                  'plotHourly': [['TInQSrc1']],
-                  'processParallel': False,
-                  'processQvsT': False,
-                  'reduceCpu': 1,
-                  'setPrintDataForGle': True,
-                  'yearReadedInMonthlyFile': -1}
 
-INPUTS_PROCESS_WITHOUT = {'calc': [],
-                          'calcCumSumHourly': [],
-                          'calcCumSumTimeStep': [],
-                          'calcDaily': [],
-                          'calcHourly': [],
-                          'calcHourlyTest': [],
-                          'calcMonthly': [],
-                          'calcMonthlyFromHourly': [],
-                          'calcMonthlyMax': [],
-                          'calcMonthlyMin': [],
-                          'calcMonthlyTest': [],
-                          'calcTest': [],
-                          'calcTimeStep': [],
-                          'calcTimeStepTest': [],
-                          'calculateHeatDemand': True,
-                          'cleanModeLatex': False,
-                          'createLatexPdf': True,
-                          'dllTrnsysPath': 'C:\\Trnsys18\\UserLib\\ReleaseDlls',
-                          'firstMonthUsed': 0,
-                          'forceProcess': True,
-                          'isTrnsys': True,
-                          'latexNames': 'latexNames.json',
-                          'numberOfYearsInHourlyFile': 1,
-                          'outputLevel': 'DEBUG',
-                          'plotHourly': [['TInQSrc1']],
-                          'processParallel': False,
-                          'processQvsT': False,
-                          'reduceCpu': 1,
-                          'setPrintDataForGle': True,
-                          'yearReadedInMonthlyFile': -1,
-                          'pathBase': _pl.WindowsPath(f'{DATA_DIR_PATH}')}
+_PROCESS_ORIGINAL_LINES = _getProcessLines()
+_PROCESS_LINES_WITHOUT = _getProcessLines(_PATH=_DATA_DIR_PATH, _without=True)
+
+
+def _getInputs(_PATH=None, _without=False, configType='run'):
+    _inputs = {'calc': [],
+               'calcCumSumHourly': [],
+               'calcCumSumTimeStep': [],
+               'calcDaily': [],
+               'calcHourly': [],
+               'calcHourlyTest': [],
+               'calcMonthly': [],
+               'calcMonthlyFromHourly': [],
+               'calcMonthlyMax': [],
+               'calcMonthlyMin': [],
+               'calcMonthlyTest': [],
+               'calcTest': [],
+               'calcTimeStep': [],
+               'calcTimeStepTest': [],
+               'reduceCpu': 4,
+               }
+    if configType == 'run':
+        _inputs['PROJECT$'] = 'C:\\Users\\epic.user\\EpicSimulation\\ddck'
+        _inputs['addAutomaticEnergyBalance'] = True
+        _inputs['checkDeck'] = True
+        _inputs['doAutoUnitNumbering'] = True
+        _inputs['generateUnitTypesUsed'] = True
+        _inputs['ignoreOnlinePlotter'] = True
+        _inputs['nameRef'] = 'DoublePipeDebug'
+        _inputs['outputLevel'] = 'INFO'
+        _inputs['parseFileCreated'] = True
+        _inputs['pathToConnectionInfo'] = 'C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json'
+        _inputs['projectPath'] = 'C:\\Users\\epic.user\\EpicSimulation'
+        _inputs['runCases'] = True
+        _inputs['runType'] = 'runFromConfig'
+        _inputs['scaling'] = 'False'
+        _inputs['trnsysExePath'] = 'C:\\Trnsys18\\Exe\\TRNExe.exe'
+        if _without:
+            _inputs['PROJECT$'] = f'{_DATA_DIR_PATH}\\ddck'
+            _inputs['pathToConnectionInfo'] = f'{_DATA_DIR_PATH}\\DdckPlaceHolderValues.json'
+            _inputs['projectPath'] = _pl.WindowsPath(f'{_DATA_DIR_PATH}')
+
+    elif configType == 'process':
+        _inputs['calculateHeatDemand'] = True
+        _inputs['cleanModeLatex'] = False
+        _inputs['createLatexPdf'] = True
+        _inputs['dllTrnsysPath'] = 'C:\\Trnsys18\\UserLib\\ReleaseDlls'
+        _inputs['firstMonthUsed'] = 0
+        _inputs['forceProcess'] = True
+        _inputs['isTrnsys'] = True
+        _inputs['latexNames'] = 'latexNames.json'
+        _inputs['numberOfYearsInHourlyFile'] = 1
+        _inputs['outputLevel'] = 'DEBUG'
+        _inputs['pathBase'] = 'C:\\Users\\epic.user\\EpicSimulation'
+        _inputs['plotHourly'] = [['TInQSrc1']]
+        _inputs['processParallel'] = False
+        _inputs['processQvsT'] = False
+        _inputs['reduceCpu'] = 1
+        _inputs['setPrintDataForGle'] = True
+        _inputs['yearReadedInMonthlyFile'] = -1
+        if _without:
+            _inputs['pathBase'] = _pl.WindowsPath(f'{_DATA_DIR_PATH}')
+
+    return _inputs
+
+
+_ORIGINAL_INPUTS = _getInputs()
+_INPUTS_WITHOUT = _getInputs(_DATA_DIR_PATH, _without=True)
+_INPUTS_PROCESS = _getInputs(configType='process')
+_INPUTS_PROCESS_WITHOUT = _getInputs(_DATA_DIR_PATH, configType='process', _without=True)
 
 
 class TestReadConfigTrnsys:
@@ -245,28 +168,28 @@ class TestReadConfigTrnsys:
 
     def testReadFileRunConfig(self):
         name = "run.config_with_absolute_paths"
-        lines = self.reader.readFile(DATA_DIR_PATH, name, self.inputs,
+        lines = self.reader.readFile(_DATA_DIR_PATH, name, self.inputs,
                                      parseFileCreated=False, controlDataType=False)
-        assert lines == ORIGINAL_LINES
-        assert self.inputs == ORIGINAL_INPUTS
+        assert lines == _ORIGINAL_LINES
+        assert self.inputs == _ORIGINAL_INPUTS
 
     def testReadFileRunConfigWithoutAnyPaths(self):
         name = "run.config_without_any_paths"
-        lines = self.reader.readFile(DATA_DIR_PATH, name, self.inputs,
+        lines = self.reader.readFile(_DATA_DIR_PATH, name, self.inputs,
                                      parseFileCreated=False, controlDataType=False)
-        assert self.inputs == INPUTS_WITHOUT
-        assert lines == LINES_WITHOUT
+        assert self.inputs == _INPUTS_WITHOUT
+        assert lines == _LINES_WITHOUT
 
     def testReadFileProcessConfig(self):
         name = "process.config_with_absolute_paths"
-        lines = self.reader.readFile(DATA_DIR_PATH, name, self.inputs,
+        lines = self.reader.readFile(_DATA_DIR_PATH, name, self.inputs,
                                      parseFileCreated=False, controlDataType=False)
-        assert self.inputs == INPUTS_PROCESS
-        assert lines == PROCESS_ORIGINAL_LINES
+        assert self.inputs == _INPUTS_PROCESS
+        assert lines == _PROCESS_ORIGINAL_LINES
 
     def testReadFileProcessConfigWithoutPaths(self):
         name = "process.config_without_paths"
-        lines = self.reader.readFile(DATA_DIR_PATH, name, self.inputs,
+        lines = self.reader.readFile(_DATA_DIR_PATH, name, self.inputs,
                                      parseFileCreated=False, controlDataType=False)
-        assert self.inputs == INPUTS_PROCESS_WITHOUT
-        assert lines == PROCESS_LINES_WITHOUT
+        assert self.inputs == _INPUTS_PROCESS_WITHOUT
+        assert lines == _PROCESS_LINES_WITHOUT

--- a/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
+++ b/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
@@ -1,0 +1,22 @@
+import pytest as _pt
+
+import pytrnsys.trnsys_util.readConfigTrnsys as _rct
+
+
+class TestReadConfigTrnsys:
+    def setup(self):
+        self.reader = _rct.ReadConfigTrnsys()
+
+    @_pt.mark.parametrize("userInput, response", [
+        ("yes", True),
+        ("Yes", True),
+        ("true", True),
+        ("True", True),
+        ("Anything_else?", False),
+        ("t", True),
+        ("T", True),
+        ("1", True),
+    ])
+    def testStr2bool(self, userInput, response):
+
+        assert self.reader.str2bool(userInput) == response

--- a/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
+++ b/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
@@ -3,33 +3,126 @@ import pathlib as _pl
 
 import pytrnsys.trnsys_util.readConfigTrnsys as _rct
 
-ORIGINAL_INPUTS = ['bool ignoreOnlinePlotter  True',
-                   'int reduceCpu  4',
-                   'bool parseFileCreated True',
-                   'bool runCases True',
-                   'bool checkDeck True',
-                   'string outputLevel "INFO"',
-                   'string pathToConnectionInfo '
-                   '"C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json"',
-                   'bool doAutoUnitNumbering True',
-                   'bool generateUnitTypesUsed True',
-                   'bool addAutomaticEnergyBalance True',
-                   'string PROJECT$ '
-                   '"C:\\Users\\epic.user\\EpicSimulation\\ddck"',
-                   'string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
-                   'string scaling "False"',
-                   'string projectPath '
-                   '"C:\\Users\\epic.user\\EpicSimulation"',
-                   'string nameRef "DoublePipeDebug"',
-                   'string runType "runFromConfig"',
-                   'deck START 0',
-                   'deck STOP  8760',
-                   'deck dtSim 1',
-                   'PROJECT$ generic\\head',
-                   'PROJECT$ control\\hydraulic_control',
-                   'PROJECT$ hydraulic\\hydraulic',
-                   'PROJECT$ QSrc1\\QSrc',
-                   'PROJECT$ generic\\end']
+DATA_DIR_PATH = _pl.Path(__file__).parent / "data"
+
+ORIGINAL_LINES = ['bool ignoreOnlinePlotter  True',
+                  'int reduceCpu  4',
+                  'bool parseFileCreated True',
+                  'bool runCases True',
+                  'bool checkDeck True',
+                  'string outputLevel "INFO"',
+                  'string pathToConnectionInfo '
+                  '"C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json"',
+                  'bool doAutoUnitNumbering True',
+                  'bool generateUnitTypesUsed True',
+                  'bool addAutomaticEnergyBalance True',
+                  'string PROJECT$ '
+                  '"C:\\Users\\epic.user\\EpicSimulation\\ddck"',
+                  'string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
+                  'string scaling "False"',
+                  'string projectPath '
+                  '"C:\\Users\\epic.user\\EpicSimulation"',
+                  'string nameRef "DoublePipeDebug"',
+                  'string runType "runFromConfig"',
+                  'deck START 0',
+                  'deck STOP  8760',
+                  'deck dtSim 1',
+                  'PROJECT$ generic\\head',
+                  'PROJECT$ control\\hydraulic_control',
+                  'PROJECT$ hydraulic\\hydraulic',
+                  'PROJECT$ QSrc1\\QSrc',
+                  'PROJECT$ generic\\end']
+
+LINES_WITHOUT = ['bool ignoreOnlinePlotter  True',
+                 'int reduceCpu  4',
+                 'bool parseFileCreated True',
+                 'bool runCases True',
+                 'bool checkDeck True',
+                 'string outputLevel "INFO"',
+                 'bool doAutoUnitNumbering True',
+                 'bool generateUnitTypesUsed True',
+                 'bool addAutomaticEnergyBalance True',
+                 'string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
+                 'string scaling "False"',
+                 'string nameRef "DoublePipeDebug"',
+                 'string runType "runFromConfig"',
+                 'deck START 0',
+                 'deck STOP  8760',
+                 'deck dtSim 1',
+                 'PROJECT$ generic\\head',
+                 'PROJECT$ control\\hydraulic_control',
+                 'PROJECT$ hydraulic\\hydraulic',
+                 'PROJECT$ QSrc1\\QSrc',
+                 'PROJECT$ generic\\end',
+                 'string pathToConnectionInfo '
+                 f'{DATA_DIR_PATH}\\DdckPlaceHolderValues.json',
+                 'string PROJECT$ '
+                 f'{DATA_DIR_PATH}\\ddck',
+                 'string projectPath '
+                 f'{DATA_DIR_PATH}']
+
+ORIGINAL_INPUTS = {'PROJECT$': 'C:\\Users\\epic.user\\EpicSimulation\\ddck',
+                   'addAutomaticEnergyBalance': True,
+                   'calc': [],
+                   'calcCumSumHourly': [],
+                   'calcCumSumTimeStep': [],
+                   'calcDaily': [],
+                   'calcHourly': [],
+                   'calcHourlyTest': [],
+                   'calcMonthly': [],
+                   'calcMonthlyFromHourly': [],
+                   'calcMonthlyMax': [],
+                   'calcMonthlyMin': [],
+                   'calcMonthlyTest': [],
+                   'calcTest': [],
+                   'calcTimeStep': [],
+                   'calcTimeStepTest': [],
+                   'checkDeck': True,
+                   'doAutoUnitNumbering': True,
+                   'generateUnitTypesUsed': True,
+                   'ignoreOnlinePlotter': True,
+                   'nameRef': 'DoublePipeDebug',
+                   'outputLevel': 'INFO',
+                   'parseFileCreated': True,
+                   'pathToConnectionInfo': 'C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json',
+                   'projectPath': 'C:\\Users\\epic.user\\EpicSimulation',
+                   'reduceCpu': 4,
+                   'runCases': True,
+                   'runType': 'runFromConfig',
+                   'scaling': 'False',
+                   'trnsysExePath': 'C:\\Trnsys18\\Exe\\TRNExe.exe'}
+
+
+INPUTS_WITHOUT = {'PROJECT$': f'{DATA_DIR_PATH}\\ddck',
+ 'addAutomaticEnergyBalance': True,
+ 'calc': [],
+ 'calcCumSumHourly': [],
+ 'calcCumSumTimeStep': [],
+ 'calcDaily': [],
+ 'calcHourly': [],
+ 'calcHourlyTest': [],
+ 'calcMonthly': [],
+ 'calcMonthlyFromHourly': [],
+ 'calcMonthlyMax': [],
+ 'calcMonthlyMin': [],
+ 'calcMonthlyTest': [],
+ 'calcTest': [],
+ 'calcTimeStep': [],
+ 'calcTimeStepTest': [],
+ 'checkDeck': True,
+ 'doAutoUnitNumbering': True,
+ 'generateUnitTypesUsed': True,
+ 'ignoreOnlinePlotter': True,
+ 'nameRef': 'DoublePipeDebug',
+ 'outputLevel': 'INFO',
+ 'parseFileCreated': True,
+ 'pathToConnectionInfo': f'{DATA_DIR_PATH}\\DdckPlaceHolderValues.json',
+ 'projectPath': _pl.WindowsPath(f'{DATA_DIR_PATH}'),
+ 'reduceCpu': 4,
+ 'runCases': True,
+ 'runType': 'runFromConfig',
+ 'scaling': 'False',
+ 'trnsysExePath': 'C:\\Trnsys18\\Exe\\TRNExe.exe'}
 
 
 class TestReadConfigTrnsys:
@@ -51,8 +144,15 @@ class TestReadConfigTrnsys:
         assert self.reader.str2bool(userInput) == response
 
     def test_readFile_runConfig(self):
-        DATA_DIR_PATH = _pl.Path(__file__).parent / "data"
-        ConfigWithAbsolutePaths = "run.config_with_absolute_paths"
-        lines = self.reader.readFile(DATA_DIR_PATH, ConfigWithAbsolutePaths, self.inputs,
+        name = "run.config_with_absolute_paths"
+        lines = self.reader.readFile(DATA_DIR_PATH, name, self.inputs,
                                      parseFileCreated=False, controlDataType=False)
-        assert lines == ORIGINAL_INPUTS
+        assert lines == ORIGINAL_LINES
+        assert self.inputs == ORIGINAL_INPUTS
+
+    def test_readFile_runConfig_without_any_paths(self):
+        name = "run.config_without_any_paths"
+        lines = self.reader.readFile(DATA_DIR_PATH, name, self.inputs,
+                                     parseFileCreated=False, controlDataType=False)
+        assert self.inputs == INPUTS_WITHOUT
+        assert lines == LINES_WITHOUT

--- a/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
+++ b/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
@@ -7,44 +7,44 @@ _DATA_DIR_PATH = _pl.Path(__file__).parent / "data"
 
 
 def _getLines(path=None, without=False):
-    _LINES = ['bool ignoreOnlinePlotter  True',
-              'int reduceCpu  4',
-              'bool parseFileCreated True',
-              'bool runCases True',
-              'bool checkDeck True',
-              'string outputLevel "INFO"', ]
+    LINES = ['bool ignoreOnlinePlotter  True',
+             'int reduceCpu  4',
+             'bool parseFileCreated True',
+             'bool runCases True',
+             'bool checkDeck True',
+             'string outputLevel "INFO"', ]
     if not without:
-        _LINES += ['string pathToConnectionInfo '
-                   '"C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json"', ]  # this one
-    _LINES += ['bool doAutoUnitNumbering True',
-               'bool generateUnitTypesUsed True',
-               'bool addAutomaticEnergyBalance True', ]
+        LINES += ['string pathToConnectionInfo '
+                  '"C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json"', ]  # this one
+    LINES += ['bool doAutoUnitNumbering True',
+              'bool generateUnitTypesUsed True',
+              'bool addAutomaticEnergyBalance True', ]
     if not without:
-        _LINES += ['string PROJECT$ '
-                   '"C:\\Users\\epic.user\\EpicSimulation\\ddck"', ]
-    _LINES += ['string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
-               'string scaling "False"', ]
+        LINES += ['string PROJECT$ '
+                  '"C:\\Users\\epic.user\\EpicSimulation\\ddck"', ]
+    LINES += ['string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
+              'string scaling "False"', ]
     if not without:
-        _LINES += ['string projectPath '
-                   '"C:\\Users\\epic.user\\EpicSimulation"', ]
-    _LINES += ['string nameRef "DoublePipeDebug"',
-               'string runType "runFromConfig"',
-               'deck START 0',
-               'deck STOP  8760',
-               'deck dtSim 1',
-               'PROJECT$ generic\\head',
-               'PROJECT$ control\\hydraulic_control',
-               'PROJECT$ hydraulic\\hydraulic',
-               'PROJECT$ QSrc1\\QSrc',
-               'PROJECT$ generic\\end']
+        LINES += ['string projectPath '
+                  '"C:\\Users\\epic.user\\EpicSimulation"', ]
+    LINES += ['string nameRef "DoublePipeDebug"',
+              'string runType "runFromConfig"',
+              'deck START 0',
+              'deck STOP  8760',
+              'deck dtSim 1',
+              'PROJECT$ generic\\head',
+              'PROJECT$ control\\hydraulic_control',
+              'PROJECT$ hydraulic\\hydraulic',
+              'PROJECT$ QSrc1\\QSrc',
+              'PROJECT$ generic\\end']
     if without:
-        _LINES += ['string pathToConnectionInfo '
-                   f'{path}\\DdckPlaceHolderValues.json',
-                   'string PROJECT$ '
-                   f'{path}\\ddck',
-                   'string projectPath '
-                   f'{path}']
-    return _LINES
+        LINES += ['string pathToConnectionInfo '
+                  f'{path}\\DdckPlaceHolderValues.json',
+                  'string PROJECT$ '
+                  f'{path}\\ddck',
+                  'string projectPath '
+                  f'{path}']
+    return LINES
 
 
 _ORIGINAL_LINES = _getLines()
@@ -52,28 +52,28 @@ _LINES_WITHOUT = _getLines(_DATA_DIR_PATH, without=True)
 
 
 def _getProcessLines(path=None, without=False):
-    _LINES = ['bool processParallel False',
-              'bool processQvsT False',
-              'bool cleanModeLatex False',
-              'bool forceProcess  True',
-              'bool setPrintDataForGle True',
-              'bool isTrnsys True',
-              'int reduceCpu 1',
-              'string outputLevel "DEBUG"',
-              'bool createLatexPdf True',
-              'bool calculateHeatDemand True',
-              'int yearReadedInMonthlyFile -1',
-              'int firstMonthUsed 0',
-              'int numberOfYearsInHourlyFile 1',
-              'string latexNames "latexNames.json"', ]
+    LINES = ['bool processParallel False',
+             'bool processQvsT False',
+             'bool cleanModeLatex False',
+             'bool forceProcess  True',
+             'bool setPrintDataForGle True',
+             'bool isTrnsys True',
+             'int reduceCpu 1',
+             'string outputLevel "DEBUG"',
+             'bool createLatexPdf True',
+             'bool calculateHeatDemand True',
+             'int yearReadedInMonthlyFile -1',
+             'int firstMonthUsed 0',
+             'int numberOfYearsInHourlyFile 1',
+             'string latexNames "latexNames.json"', ]
     if not without:
-        _LINES += ['string pathBase "C:\\Users\\epic.user\\EpicSimulation"', ]
-    _LINES += ['string dllTrnsysPath "C:\\Trnsys18\\UserLib\\ReleaseDlls"',
-               'stringArray plotHourly "TInQSrc1"']
+        LINES += ['string pathBase "C:\\Users\\epic.user\\EpicSimulation"', ]
+    LINES += ['string dllTrnsysPath "C:\\Trnsys18\\UserLib\\ReleaseDlls"',
+              'stringArray plotHourly "TInQSrc1"']
     if without:
-        _LINES += ['string pathBase '
-                   f'{path}']
-    return _LINES
+        LINES += ['string pathBase '
+                  f'{path}']
+    return LINES
 
 
 _PROCESS_ORIGINAL_LINES = _getProcessLines()
@@ -81,65 +81,65 @@ _PROCESS_LINES_WITHOUT = _getProcessLines(path=_DATA_DIR_PATH, without=True)
 
 
 def _getInputs(path=None, without=False, configType='run'):
-    _inputs = {'calc': [],
-               'calcCumSumHourly': [],
-               'calcCumSumTimeStep': [],
-               'calcDaily': [],
-               'calcHourly': [],
-               'calcHourlyTest': [],
-               'calcMonthly': [],
-               'calcMonthlyFromHourly': [],
-               'calcMonthlyMax': [],
-               'calcMonthlyMin': [],
-               'calcMonthlyTest': [],
-               'calcTest': [],
-               'calcTimeStep': [],
-               'calcTimeStepTest': [],
-               'reduceCpu': 4,
-               }
+    inputs = {'calc': [],
+              'calcCumSumHourly': [],
+              'calcCumSumTimeStep': [],
+              'calcDaily': [],
+              'calcHourly': [],
+              'calcHourlyTest': [],
+              'calcMonthly': [],
+              'calcMonthlyFromHourly': [],
+              'calcMonthlyMax': [],
+              'calcMonthlyMin': [],
+              'calcMonthlyTest': [],
+              'calcTest': [],
+              'calcTimeStep': [],
+              'calcTimeStepTest': [],
+              'reduceCpu': 4,
+              }
     if configType == 'run':
-        _inputs['PROJECT$'] = 'C:\\Users\\epic.user\\EpicSimulation\\ddck'
-        _inputs['addAutomaticEnergyBalance'] = True
-        _inputs['checkDeck'] = True
-        _inputs['doAutoUnitNumbering'] = True
-        _inputs['generateUnitTypesUsed'] = True
-        _inputs['ignoreOnlinePlotter'] = True
-        _inputs['nameRef'] = 'DoublePipeDebug'
-        _inputs['outputLevel'] = 'INFO'
-        _inputs['parseFileCreated'] = True
-        _inputs['pathToConnectionInfo'] = 'C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json'
-        _inputs['projectPath'] = 'C:\\Users\\epic.user\\EpicSimulation'
-        _inputs['runCases'] = True
-        _inputs['runType'] = 'runFromConfig'
-        _inputs['scaling'] = 'False'
-        _inputs['trnsysExePath'] = 'C:\\Trnsys18\\Exe\\TRNExe.exe'
+        inputs['PROJECT$'] = 'C:\\Users\\epic.user\\EpicSimulation\\ddck'
+        inputs['addAutomaticEnergyBalance'] = True
+        inputs['checkDeck'] = True
+        inputs['doAutoUnitNumbering'] = True
+        inputs['generateUnitTypesUsed'] = True
+        inputs['ignoreOnlinePlotter'] = True
+        inputs['nameRef'] = 'DoublePipeDebug'
+        inputs['outputLevel'] = 'INFO'
+        inputs['parseFileCreated'] = True
+        inputs['pathToConnectionInfo'] = 'C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json'
+        inputs['projectPath'] = 'C:\\Users\\epic.user\\EpicSimulation'
+        inputs['runCases'] = True
+        inputs['runType'] = 'runFromConfig'
+        inputs['scaling'] = 'False'
+        inputs['trnsysExePath'] = 'C:\\Trnsys18\\Exe\\TRNExe.exe'
         if without:
-            _inputs['PROJECT$'] = f'{path}\\ddck'
-            _inputs['pathToConnectionInfo'] = f'{path}\\DdckPlaceHolderValues.json'
-            _inputs['projectPath'] = _pl.WindowsPath(f'{path}')
+            inputs['PROJECT$'] = f'{path}\\ddck'
+            inputs['pathToConnectionInfo'] = f'{path}\\DdckPlaceHolderValues.json'
+            inputs['projectPath'] = _pl.WindowsPath(f'{path}')
 
     elif configType == 'process':
-        _inputs['calculateHeatDemand'] = True
-        _inputs['cleanModeLatex'] = False
-        _inputs['createLatexPdf'] = True
-        _inputs['dllTrnsysPath'] = 'C:\\Trnsys18\\UserLib\\ReleaseDlls'
-        _inputs['firstMonthUsed'] = 0
-        _inputs['forceProcess'] = True
-        _inputs['isTrnsys'] = True
-        _inputs['latexNames'] = 'latexNames.json'
-        _inputs['numberOfYearsInHourlyFile'] = 1
-        _inputs['outputLevel'] = 'DEBUG'
-        _inputs['pathBase'] = 'C:\\Users\\epic.user\\EpicSimulation'
-        _inputs['plotHourly'] = [['TInQSrc1']]
-        _inputs['processParallel'] = False
-        _inputs['processQvsT'] = False
-        _inputs['reduceCpu'] = 1
-        _inputs['setPrintDataForGle'] = True
-        _inputs['yearReadedInMonthlyFile'] = -1
+        inputs['calculateHeatDemand'] = True
+        inputs['cleanModeLatex'] = False
+        inputs['createLatexPdf'] = True
+        inputs['dllTrnsysPath'] = 'C:\\Trnsys18\\UserLib\\ReleaseDlls'
+        inputs['firstMonthUsed'] = 0
+        inputs['forceProcess'] = True
+        inputs['isTrnsys'] = True
+        inputs['latexNames'] = 'latexNames.json'
+        inputs['numberOfYearsInHourlyFile'] = 1
+        inputs['outputLevel'] = 'DEBUG'
+        inputs['pathBase'] = 'C:\\Users\\epic.user\\EpicSimulation'
+        inputs['plotHourly'] = [['TInQSrc1']]
+        inputs['processParallel'] = False
+        inputs['processQvsT'] = False
+        inputs['reduceCpu'] = 1
+        inputs['setPrintDataForGle'] = True
+        inputs['yearReadedInMonthlyFile'] = -1
         if without:
-            _inputs['pathBase'] = _pl.WindowsPath(f'{path}')
+            inputs['pathBase'] = _pl.WindowsPath(f'{path}')
 
-    return _inputs
+    return inputs
 
 
 _ORIGINAL_INPUTS = _getInputs()

--- a/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
+++ b/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
@@ -1,11 +1,41 @@
 import pytest as _pt
+import pathlib as _pl
 
 import pytrnsys.trnsys_util.readConfigTrnsys as _rct
+
+ORIGINAL_INPUTS = ['bool ignoreOnlinePlotter  True',
+                   'int reduceCpu  4',
+                   'bool parseFileCreated True',
+                   'bool runCases True',
+                   'bool checkDeck True',
+                   'string outputLevel "INFO"',
+                   'string pathToConnectionInfo '
+                   '"C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json"',
+                   'bool doAutoUnitNumbering True',
+                   'bool generateUnitTypesUsed True',
+                   'bool addAutomaticEnergyBalance True',
+                   'string PROJECT$ '
+                   '"C:\\Users\\epic.user\\EpicSimulation\\ddck"',
+                   'string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
+                   'string scaling "False"',
+                   'string projectPath '
+                   '"C:\\Users\\epic.user\\EpicSimulation"',
+                   'string nameRef "DoublePipeDebug"',
+                   'string runType "runFromConfig"',
+                   'deck START 0',
+                   'deck STOP  8760',
+                   'deck dtSim 1',
+                   'PROJECT$ generic\\head',
+                   'PROJECT$ control\\hydraulic_control',
+                   'PROJECT$ hydraulic\\hydraulic',
+                   'PROJECT$ QSrc1\\QSrc',
+                   'PROJECT$ generic\\end']
 
 
 class TestReadConfigTrnsys:
     def setup(self):
         self.reader = _rct.ReadConfigTrnsys()
+        self.inputs = {}
 
     @_pt.mark.parametrize("userInput, response", [
         ("yes", True),
@@ -18,5 +48,11 @@ class TestReadConfigTrnsys:
         ("1", True),
     ])
     def testStr2bool(self, userInput, response):
-
         assert self.reader.str2bool(userInput) == response
+
+    def test_readFile_runConfig(self):
+        DATA_DIR_PATH = _pl.Path(__file__).parent / "data"
+        ConfigWithAbsolutePaths = "run.config_with_absolute_paths"
+        lines = self.reader.readFile(DATA_DIR_PATH, ConfigWithAbsolutePaths, self.inputs,
+                                     parseFileCreated=False, controlDataType=False)
+        assert lines == ORIGINAL_INPUTS

--- a/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
+++ b/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
@@ -1,5 +1,5 @@
-import pytest as _pt
 import pathlib as _pl
+import pytest as _pt
 
 import pytrnsys.trnsys_util.readConfigTrnsys as _rct
 
@@ -61,6 +61,43 @@ LINES_WITHOUT = ['bool ignoreOnlinePlotter  True',
                  'string projectPath '
                  f'{DATA_DIR_PATH}']
 
+PROCESS_ORIGINAL_LINES = ['bool processParallel False',
+                          'bool processQvsT False',
+                          'bool cleanModeLatex False',
+                          'bool forceProcess  True',
+                          'bool setPrintDataForGle True',
+                          'bool isTrnsys True',
+                          'int reduceCpu 1',
+                          'string outputLevel "DEBUG"',
+                          'bool createLatexPdf True',
+                          'bool calculateHeatDemand True',
+                          'int yearReadedInMonthlyFile -1',
+                          'int firstMonthUsed 0',
+                          'int numberOfYearsInHourlyFile 1',
+                          'string latexNames "latexNames.json"',
+                          'string pathBase "C:\\Users\\epic.user\\EpicSimulation"',
+                          'string dllTrnsysPath "C:\\Trnsys18\\UserLib\\ReleaseDlls"',
+                          'stringArray plotHourly "TInQSrc1"']
+
+PROCESS_LINES_WITHOUT = ['bool processParallel False',
+                         'bool processQvsT False',
+                         'bool cleanModeLatex False',
+                         'bool forceProcess  True',
+                         'bool setPrintDataForGle True',
+                         'bool isTrnsys True',
+                         'int reduceCpu 1',
+                         'string outputLevel "DEBUG"',
+                         'bool createLatexPdf True',
+                         'bool calculateHeatDemand True',
+                         'int yearReadedInMonthlyFile -1',
+                         'int firstMonthUsed 0',
+                         'int numberOfYearsInHourlyFile 1',
+                         'string latexNames "latexNames.json"',
+                         'string dllTrnsysPath "C:\\Trnsys18\\UserLib\\ReleaseDlls"',
+                         'stringArray plotHourly "TInQSrc1"',
+                         'string pathBase '
+                         f'{DATA_DIR_PATH}']
+
 ORIGINAL_INPUTS = {'PROJECT$': 'C:\\Users\\epic.user\\EpicSimulation\\ddck',
                    'addAutomaticEnergyBalance': True,
                    'calc': [],
@@ -92,43 +129,106 @@ ORIGINAL_INPUTS = {'PROJECT$': 'C:\\Users\\epic.user\\EpicSimulation\\ddck',
                    'scaling': 'False',
                    'trnsysExePath': 'C:\\Trnsys18\\Exe\\TRNExe.exe'}
 
-
 INPUTS_WITHOUT = {'PROJECT$': f'{DATA_DIR_PATH}\\ddck',
- 'addAutomaticEnergyBalance': True,
- 'calc': [],
- 'calcCumSumHourly': [],
- 'calcCumSumTimeStep': [],
- 'calcDaily': [],
- 'calcHourly': [],
- 'calcHourlyTest': [],
- 'calcMonthly': [],
- 'calcMonthlyFromHourly': [],
- 'calcMonthlyMax': [],
- 'calcMonthlyMin': [],
- 'calcMonthlyTest': [],
- 'calcTest': [],
- 'calcTimeStep': [],
- 'calcTimeStepTest': [],
- 'checkDeck': True,
- 'doAutoUnitNumbering': True,
- 'generateUnitTypesUsed': True,
- 'ignoreOnlinePlotter': True,
- 'nameRef': 'DoublePipeDebug',
- 'outputLevel': 'INFO',
- 'parseFileCreated': True,
- 'pathToConnectionInfo': f'{DATA_DIR_PATH}\\DdckPlaceHolderValues.json',
- 'projectPath': _pl.WindowsPath(f'{DATA_DIR_PATH}'),
- 'reduceCpu': 4,
- 'runCases': True,
- 'runType': 'runFromConfig',
- 'scaling': 'False',
- 'trnsysExePath': 'C:\\Trnsys18\\Exe\\TRNExe.exe'}
+                  'addAutomaticEnergyBalance': True,
+                  'calc': [],
+                  'calcCumSumHourly': [],
+                  'calcCumSumTimeStep': [],
+                  'calcDaily': [],
+                  'calcHourly': [],
+                  'calcHourlyTest': [],
+                  'calcMonthly': [],
+                  'calcMonthlyFromHourly': [],
+                  'calcMonthlyMax': [],
+                  'calcMonthlyMin': [],
+                  'calcMonthlyTest': [],
+                  'calcTest': [],
+                  'calcTimeStep': [],
+                  'calcTimeStepTest': [],
+                  'checkDeck': True,
+                  'doAutoUnitNumbering': True,
+                  'generateUnitTypesUsed': True,
+                  'ignoreOnlinePlotter': True,
+                  'nameRef': 'DoublePipeDebug',
+                  'outputLevel': 'INFO',
+                  'parseFileCreated': True,
+                  'pathToConnectionInfo': f'{DATA_DIR_PATH}\\DdckPlaceHolderValues.json',
+                  'projectPath': _pl.WindowsPath(f'{DATA_DIR_PATH}'),
+                  'reduceCpu': 4,
+                  'runCases': True,
+                  'runType': 'runFromConfig',
+                  'scaling': 'False',
+                  'trnsysExePath': 'C:\\Trnsys18\\Exe\\TRNExe.exe'}
+
+INPUTS_PROCESS = {'calc': [],
+                  'calcCumSumHourly': [],
+                  'calcCumSumTimeStep': [],
+                  'calcDaily': [],
+                  'calcHourly': [],
+                  'calcHourlyTest': [],
+                  'calcMonthly': [],
+                  'calcMonthlyFromHourly': [],
+                  'calcMonthlyMax': [],
+                  'calcMonthlyMin': [],
+                  'calcMonthlyTest': [],
+                  'calcTest': [],
+                  'calcTimeStep': [],
+                  'calcTimeStepTest': [],
+                  'calculateHeatDemand': True,
+                  'cleanModeLatex': False,
+                  'createLatexPdf': True,
+                  'dllTrnsysPath': 'C:\\Trnsys18\\UserLib\\ReleaseDlls',
+                  'firstMonthUsed': 0,
+                  'forceProcess': True,
+                  'isTrnsys': True,
+                  'latexNames': 'latexNames.json',
+                  'numberOfYearsInHourlyFile': 1,
+                  'outputLevel': 'DEBUG',
+                  'pathBase': 'C:\\Users\\epic.user\\EpicSimulation',
+                  'plotHourly': [['TInQSrc1']],
+                  'processParallel': False,
+                  'processQvsT': False,
+                  'reduceCpu': 1,
+                  'setPrintDataForGle': True,
+                  'yearReadedInMonthlyFile': -1}
+
+INPUTS_PROCESS_WITHOUT = {'calc': [],
+                          'calcCumSumHourly': [],
+                          'calcCumSumTimeStep': [],
+                          'calcDaily': [],
+                          'calcHourly': [],
+                          'calcHourlyTest': [],
+                          'calcMonthly': [],
+                          'calcMonthlyFromHourly': [],
+                          'calcMonthlyMax': [],
+                          'calcMonthlyMin': [],
+                          'calcMonthlyTest': [],
+                          'calcTest': [],
+                          'calcTimeStep': [],
+                          'calcTimeStepTest': [],
+                          'calculateHeatDemand': True,
+                          'cleanModeLatex': False,
+                          'createLatexPdf': True,
+                          'dllTrnsysPath': 'C:\\Trnsys18\\UserLib\\ReleaseDlls',
+                          'firstMonthUsed': 0,
+                          'forceProcess': True,
+                          'isTrnsys': True,
+                          'latexNames': 'latexNames.json',
+                          'numberOfYearsInHourlyFile': 1,
+                          'outputLevel': 'DEBUG',
+                          'plotHourly': [['TInQSrc1']],
+                          'processParallel': False,
+                          'processQvsT': False,
+                          'reduceCpu': 1,
+                          'setPrintDataForGle': True,
+                          'yearReadedInMonthlyFile': -1,
+                          'pathBase': _pl.WindowsPath(f'{DATA_DIR_PATH}')}
 
 
 class TestReadConfigTrnsys:
     def setup(self):
-        self.reader = _rct.ReadConfigTrnsys()
-        self.inputs = {}
+        self.reader = _rct.ReadConfigTrnsys()  # pylint: disable=attribute-defined-outside-init
+        self.inputs = {}  # pylint: disable=attribute-defined-outside-init
 
     @_pt.mark.parametrize("userInput, response", [
         ("yes", True),
@@ -143,16 +243,30 @@ class TestReadConfigTrnsys:
     def testStr2bool(self, userInput, response):
         assert self.reader.str2bool(userInput) == response
 
-    def test_readFile_runConfig(self):
+    def testReadFileRunConfig(self):
         name = "run.config_with_absolute_paths"
         lines = self.reader.readFile(DATA_DIR_PATH, name, self.inputs,
                                      parseFileCreated=False, controlDataType=False)
         assert lines == ORIGINAL_LINES
         assert self.inputs == ORIGINAL_INPUTS
 
-    def test_readFile_runConfig_without_any_paths(self):
+    def testReadFileRunConfigWithoutAnyPaths(self):
         name = "run.config_without_any_paths"
         lines = self.reader.readFile(DATA_DIR_PATH, name, self.inputs,
                                      parseFileCreated=False, controlDataType=False)
         assert self.inputs == INPUTS_WITHOUT
         assert lines == LINES_WITHOUT
+
+    def testReadFileProcessConfig(self):
+        name = "process.config_with_absolute_paths"
+        lines = self.reader.readFile(DATA_DIR_PATH, name, self.inputs,
+                                     parseFileCreated=False, controlDataType=False)
+        assert self.inputs == INPUTS_PROCESS
+        assert lines == PROCESS_ORIGINAL_LINES
+
+    def testReadFileProcessConfigWithoutPaths(self):
+        name = "process.config_without_paths"
+        lines = self.reader.readFile(DATA_DIR_PATH, name, self.inputs,
+                                     parseFileCreated=False, controlDataType=False)
+        assert self.inputs == INPUTS_PROCESS_WITHOUT
+        assert lines == PROCESS_LINES_WITHOUT

--- a/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
+++ b/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
@@ -116,7 +116,7 @@ def _getInputs(path=None, without=False, configType='run'):
         if without:
             inputs['PROJECT$'] = f'{path}\\ddck'
             inputs['pathToConnectionInfo'] = f'{path}\\DdckPlaceHolderValues.json'
-            inputs['projectPath'] = _pl.WindowsPath(f'{path}')
+            inputs['projectPath'] = _pl.Path(f'{path}')
 
     elif configType == 'process':
         inputs['calculateHeatDemand'] = True
@@ -137,7 +137,7 @@ def _getInputs(path=None, without=False, configType='run'):
         inputs['setPrintDataForGle'] = True
         inputs['yearReadedInMonthlyFile'] = -1
         if without:
-            inputs['pathBase'] = _pl.WindowsPath(f'{path}')
+            inputs['pathBase'] = _pl.Path(f'{path}')
 
     return inputs
 

--- a/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
+++ b/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
@@ -1,5 +1,6 @@
 import pathlib as _pl
-import os as _os
+import typing as _tp
+
 import pytest as _pt
 
 import pytrnsys.trnsys_util.readConfigTrnsys as _rct
@@ -7,146 +8,161 @@ import pytrnsys.trnsys_util.readConfigTrnsys as _rct
 _DATA_DIR_PATH = _pl.Path(__file__).parent / "data"
 
 
-def _getLines(path=None, without=False):
-    lines = ['bool ignoreOnlinePlotter  True',
-             'int reduceCpu  4',
-             'bool parseFileCreated True',
-             'bool runCases True',
-             'bool checkDeck True',
-             'string outputLevel "INFO"', ]
-    if not without:
-        lines += ['string pathToConnectionInfo '
-                  '"C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json"', ]  # this one
-    lines += ['bool doAutoUnitNumbering True',
-              'bool generateUnitTypesUsed True',
-              'bool addAutomaticEnergyBalance True', ]
-    if not without:
-        lines += ['string PROJECT$ '
-                  '"C:\\Users\\epic.user\\EpicSimulation\\ddck"', ]
-    lines += ['string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
-              'string scaling "False"', ]
-    if not without:
-        lines += ['string projectPath '
-                  '"C:\\Users\\epic.user\\EpicSimulation"', ]
-    lines += ['string nameRef "DoublePipeDebug"',
-              'string runType "runFromConfig"',
-              'deck START 0',
-              'deck STOP  8760',
-              'deck dtSim 1',
-              'PROJECT$ generic\\head',
-              'PROJECT$ control\\hydraulic_control',
-              'PROJECT$ hydraulic\\hydraulic',
-              'PROJECT$ QSrc1\\QSrc',
-              'PROJECT$ generic\\end']
-    if without:
-        lines += ['string pathToConnectionInfo '
-                  f'{_os.path.join(path, "DdckPlaceHolderValues.json")}',
-                  'string PROJECT$ '
-                  f'{_os.path.join(path, "ddck")}',
-                  'string projectPath '
-                  f'{path}']
+def _getRunLines(basePath: _tp.Optional[_pl.Path]) -> _tp.Sequence[str]:
+    lines = [
+        "bool ignoreOnlinePlotter  True",
+        "int reduceCpu  4",
+        "bool parseFileCreated True",
+        "bool runCases True",
+        "bool checkDeck True",
+        'string outputLevel "INFO"',
+    ]
+    if not basePath:
+        lines += [
+            'string pathToConnectionInfo "C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json"',
+        ]
+    lines += [
+        "bool doAutoUnitNumbering True",
+        "bool generateUnitTypesUsed True",
+        "bool addAutomaticEnergyBalance True",
+    ]
+    if not basePath:
+        lines += [
+            'string PROJECT$ "C:\\Users\\epic.user\\EpicSimulation\\ddck"',
+        ]
+    lines += [
+        'string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
+        'string scaling "False"',
+    ]
+    if not basePath:
+        lines += [
+            'string projectPath "C:\\Users\\epic.user\\EpicSimulation"',
+        ]
+    lines += [
+        'string nameRef "DoublePipeDebug"',
+        'string runType "runFromConfig"',
+        "deck START 0",
+        "deck STOP  8760",
+        "deck dtSim 1",
+        "PROJECT$ generic\\head",
+        "PROJECT$ control\\hydraulic_control",
+        "PROJECT$ hydraulic\\hydraulic",
+        "PROJECT$ QSrc1\\QSrc",
+        "PROJECT$ generic\\end",
+    ]
+    if basePath:
+        lines += [
+            f"string pathToConnectionInfo {basePath / 'DdckPlaceHolderValues.json'}",
+            f"string PROJECT$ {basePath / 'ddck'}",
+            f"string projectPath {basePath}",
+        ]
     return lines
 
 
-_ORIGINAL_LINES = _getLines()
-_LINES_WITHOUT = _getLines(_DATA_DIR_PATH, without=True)
+_LINES_RUN = _getRunLines(basePath=None)
+_LINES_RUN_WITHOUT_PATHS = _getRunLines(basePath=_DATA_DIR_PATH)
 
 
-def _getProcessLines(path=None, without=False):
-    lines = ['bool processParallel False',
-             'bool processQvsT False',
-             'bool cleanModeLatex False',
-             'bool forceProcess  True',
-             'bool setPrintDataForGle True',
-             'bool isTrnsys True',
-             'int reduceCpu 1',
-             'string outputLevel "DEBUG"',
-             'bool createLatexPdf True',
-             'bool calculateHeatDemand True',
-             'int yearReadedInMonthlyFile -1',
-             'int firstMonthUsed 0',
-             'int numberOfYearsInHourlyFile 1',
-             'string latexNames "latexNames.json"', ]
-    if not without:
-        lines += ['string pathBase "C:\\Users\\epic.user\\EpicSimulation"', ]
-    lines += ['string dllTrnsysPath "C:\\Trnsys18\\UserLib\\ReleaseDlls"',
-              'stringArray plotHourly "TInQSrc1"']
-    if without:
-        lines += ['string pathBase '
-                  f'{path}']
+def _getProcessLines(basePath: _tp.Optional[_pl.Path]) -> _tp.Sequence[str]:
+    lines = [
+        "bool processParallel False",
+        "bool processQvsT False",
+        "bool cleanModeLatex False",
+        "bool forceProcess  True",
+        "bool setPrintDataForGle True",
+        "bool isTrnsys True",
+        "int reduceCpu 1",
+        'string outputLevel "DEBUG"',
+        "bool createLatexPdf True",
+        "bool calculateHeatDemand True",
+        "int yearReadedInMonthlyFile -1",
+        "int firstMonthUsed 0",
+        "int numberOfYearsInHourlyFile 1",
+        'string latexNames "latexNames.json"',
+    ]
+    if not basePath:
+        lines += [
+            'string pathBase "C:\\Users\\epic.user\\EpicSimulation"',
+        ]
+    lines += ['string dllTrnsysPath "C:\\Trnsys18\\UserLib\\ReleaseDlls"', 'stringArray plotHourly "TInQSrc1"']
+    if basePath:
+        lines += [f"string pathBase {basePath}"]
     return lines
 
 
-_PROCESS_ORIGINAL_LINES = _getProcessLines()
-_PROCESS_LINES_WITHOUT = _getProcessLines(path=_DATA_DIR_PATH, without=True)
+_PROCESS_LINES = _getProcessLines(basePath=None)
+_PROCESS_LINES_WITHOUT_PATHS = _getProcessLines(basePath=_DATA_DIR_PATH)
 
 
-def _getInputs(path=None, without=False, configType='run'):
-    inputs = {'calc': [],
-              'calcCumSumHourly': [],
-              'calcCumSumTimeStep': [],
-              'calcDaily': [],
-              'calcHourly': [],
-              'calcHourlyTest': [],
-              'calcMonthly': [],
-              'calcMonthlyFromHourly': [],
-              'calcMonthlyMax': [],
-              'calcMonthlyMin': [],
-              'calcMonthlyTest': [],
-              'calcTest': [],
-              'calcTimeStep': [],
-              'calcTimeStepTest': [],
-              'reduceCpu': 4,
-              }
-    if configType == 'run':
-        inputs['PROJECT$'] = 'C:\\Users\\epic.user\\EpicSimulation\\ddck'
-        inputs['addAutomaticEnergyBalance'] = True
-        inputs['checkDeck'] = True
-        inputs['doAutoUnitNumbering'] = True
-        inputs['generateUnitTypesUsed'] = True
-        inputs['ignoreOnlinePlotter'] = True
-        inputs['nameRef'] = 'DoublePipeDebug'
-        inputs['outputLevel'] = 'INFO'
-        inputs['parseFileCreated'] = True
-        inputs['pathToConnectionInfo'] = 'C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json'
-        inputs['projectPath'] = 'C:\\Users\\epic.user\\EpicSimulation'
-        inputs['runCases'] = True
-        inputs['runType'] = 'runFromConfig'
-        inputs['scaling'] = 'False'
-        inputs['trnsysExePath'] = 'C:\\Trnsys18\\Exe\\TRNExe.exe'
-        if without:
-            inputs['PROJECT$'] = f'{_os.path.join(path, "ddck")}'
-            inputs['pathToConnectionInfo'] = f'{_os.path.join(path, "DdckPlaceHolderValues.json")}'
-            inputs['projectPath'] = _pl.Path(f'{path}')
+def _getInputs(
+    basePath: _tp.Optional[_pl.Path], configType: _tp.Literal["run", "process"]
+) -> _tp.Mapping[str, _tp.Any]:
+    inputs = {
+        "calc": [],
+        "calcCumSumHourly": [],
+        "calcCumSumTimeStep": [],
+        "calcDaily": [],
+        "calcHourly": [],
+        "calcHourlyTest": [],
+        "calcMonthly": [],
+        "calcMonthlyFromHourly": [],
+        "calcMonthlyMax": [],
+        "calcMonthlyMin": [],
+        "calcMonthlyTest": [],
+        "calcTest": [],
+        "calcTimeStep": [],
+        "calcTimeStepTest": [],
+        "reduceCpu": 4,
+    }
+    if configType == "run":
+        inputs["PROJECT$"] = "C:\\Users\\epic.user\\EpicSimulation\\ddck"
+        inputs["addAutomaticEnergyBalance"] = True
+        inputs["checkDeck"] = True
+        inputs["doAutoUnitNumbering"] = True
+        inputs["generateUnitTypesUsed"] = True
+        inputs["ignoreOnlinePlotter"] = True
+        inputs["nameRef"] = "DoublePipeDebug"
+        inputs["outputLevel"] = "INFO"
+        inputs["parseFileCreated"] = True
+        inputs["pathToConnectionInfo"] = "C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json"
+        inputs["projectPath"] = "C:\\Users\\epic.user\\EpicSimulation"
+        inputs["runCases"] = True
+        inputs["runType"] = "runFromConfig"
+        inputs["scaling"] = "False"
+        inputs["trnsysExePath"] = "C:\\Trnsys18\\Exe\\TRNExe.exe"
+        if basePath:
+            inputs["PROJECT$"] = str(basePath / "ddck")
+            inputs["pathToConnectionInfo"] = str(basePath / "DdckPlaceHolderValues.json")
+            inputs["projectPath"] = basePath
 
-    elif configType == 'process':
-        inputs['calculateHeatDemand'] = True
-        inputs['cleanModeLatex'] = False
-        inputs['createLatexPdf'] = True
-        inputs['dllTrnsysPath'] = 'C:\\Trnsys18\\UserLib\\ReleaseDlls'
-        inputs['firstMonthUsed'] = 0
-        inputs['forceProcess'] = True
-        inputs['isTrnsys'] = True
-        inputs['latexNames'] = 'latexNames.json'
-        inputs['numberOfYearsInHourlyFile'] = 1
-        inputs['outputLevel'] = 'DEBUG'
-        inputs['pathBase'] = 'C:\\Users\\epic.user\\EpicSimulation'
-        inputs['plotHourly'] = [['TInQSrc1']]
-        inputs['processParallel'] = False
-        inputs['processQvsT'] = False
-        inputs['reduceCpu'] = 1
-        inputs['setPrintDataForGle'] = True
-        inputs['yearReadedInMonthlyFile'] = -1
-        if without:
-            inputs['pathBase'] = _pl.Path(f'{path}')
+    elif configType == "process":
+        inputs["calculateHeatDemand"] = True
+        inputs["cleanModeLatex"] = False
+        inputs["createLatexPdf"] = True
+        inputs["dllTrnsysPath"] = "C:\\Trnsys18\\UserLib\\ReleaseDlls"
+        inputs["firstMonthUsed"] = 0
+        inputs["forceProcess"] = True
+        inputs["isTrnsys"] = True
+        inputs["latexNames"] = "latexNames.json"
+        inputs["numberOfYearsInHourlyFile"] = 1
+        inputs["outputLevel"] = "DEBUG"
+        inputs["pathBase"] = "C:\\Users\\epic.user\\EpicSimulation"
+        inputs["plotHourly"] = [["TInQSrc1"]]
+        inputs["processParallel"] = False
+        inputs["processQvsT"] = False
+        inputs["reduceCpu"] = 1
+        inputs["setPrintDataForGle"] = True
+        inputs["yearReadedInMonthlyFile"] = -1
+        if basePath:
+            inputs["pathBase"] = basePath
 
     return inputs
 
 
-_ORIGINAL_INPUTS = _getInputs()
-_INPUTS_WITHOUT = _getInputs(_DATA_DIR_PATH, without=True)
-_INPUTS_PROCESS = _getInputs(configType='process')
-_INPUTS_PROCESS_WITHOUT = _getInputs(_DATA_DIR_PATH, without=True, configType='process')
+_INPUTS_RUN = _getInputs(basePath=None, configType="run")
+_INPUTS_RUN_WITHOUT_PATHS = _getInputs(basePath=_DATA_DIR_PATH, configType="run")
+_INPUTS_PROCESS = _getInputs(basePath=None, configType="process")
+_INPUTS_PROCESS_WITHOUT_PATHS = _getInputs(basePath=_DATA_DIR_PATH, configType="process")
 
 
 class TestReadConfigTrnsys:
@@ -154,43 +170,42 @@ class TestReadConfigTrnsys:
         self.reader = _rct.ReadConfigTrnsys()  # pylint: disable=attribute-defined-outside-init
         self.inputs = {}  # pylint: disable=attribute-defined-outside-init
 
-    @_pt.mark.parametrize("userInput, response", [
-        ("yes", True),
-        ("Yes", True),
-        ("true", True),
-        ("True", True),
-        ("Anything_else?", False),
-        ("t", True),
-        ("T", True),
-        ("1", True),
-    ])
+    @_pt.mark.parametrize(
+        "userInput, response",
+        [
+            ("yes", True),
+            ("Yes", True),
+            ("true", True),
+            ("True", True),
+            ("Anything_else?", False),
+            ("t", True),
+            ("T", True),
+            ("1", True),
+        ],
+    )
     def testStr2bool(self, userInput, response):
         assert self.reader.str2bool(userInput) == response
 
     def testReadFileRunConfig(self):
         name = "run.config_with_absolute_paths"
-        lines = self.reader.readFile(_DATA_DIR_PATH, name, self.inputs,
-                                     parseFileCreated=False, controlDataType=False)
-        assert lines == _ORIGINAL_LINES
-        assert self.inputs == _ORIGINAL_INPUTS
+        lines = self.reader.readFile(_DATA_DIR_PATH, name, self.inputs, parseFileCreated=False, controlDataType=False)
+        assert self.inputs == _INPUTS_RUN
+        assert lines == _LINES_RUN
 
     def testReadFileRunConfigWithoutAnyPaths(self):
         name = "run.config_without_any_paths"
-        lines = self.reader.readFile(_DATA_DIR_PATH, name, self.inputs,
-                                     parseFileCreated=False, controlDataType=False)
-        assert self.inputs == _INPUTS_WITHOUT
-        assert lines == _LINES_WITHOUT
+        lines = self.reader.readFile(_DATA_DIR_PATH, name, self.inputs, parseFileCreated=False, controlDataType=False)
+        assert self.inputs == _INPUTS_RUN_WITHOUT_PATHS
+        assert lines == _LINES_RUN_WITHOUT_PATHS
 
     def testReadFileProcessConfig(self):
         name = "process.config_with_absolute_paths"
-        lines = self.reader.readFile(_DATA_DIR_PATH, name, self.inputs,
-                                     parseFileCreated=False, controlDataType=False)
+        lines = self.reader.readFile(_DATA_DIR_PATH, name, self.inputs, parseFileCreated=False, controlDataType=False)
         assert self.inputs == _INPUTS_PROCESS
-        assert lines == _PROCESS_ORIGINAL_LINES
+        assert lines == _PROCESS_LINES
 
     def testReadFileProcessConfigWithoutPaths(self):
         name = "process.config_without_paths"
-        lines = self.reader.readFile(_DATA_DIR_PATH, name, self.inputs,
-                                     parseFileCreated=False, controlDataType=False)
-        assert self.inputs == _INPUTS_PROCESS_WITHOUT
-        assert lines == _PROCESS_LINES_WITHOUT
+        lines = self.reader.readFile(_DATA_DIR_PATH, name, self.inputs, parseFileCreated=False, controlDataType=False)
+        assert self.inputs == _INPUTS_PROCESS_WITHOUT_PATHS
+        assert lines == _PROCESS_LINES_WITHOUT_PATHS

--- a/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
+++ b/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
@@ -1,6 +1,6 @@
 import pathlib as _pl
-import pytest as _pt
 import os as _os
+import pytest as _pt
 
 import pytrnsys.trnsys_util.readConfigTrnsys as _rct
 

--- a/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
+++ b/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
@@ -19,7 +19,7 @@ def _getRunLines(basePath: _tp.Optional[_pl.Path]) -> _tp.Sequence[str]:
     ]
     if not basePath:
         lines += [
-            'string pathToConnectionInfo "C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json"',
+            r'string pathToConnectionInfo "C:\Users\epic.user\EpicSimulation\DdckPlaceHolderValues.json"',
         ]
     lines += [
         "bool doAutoUnitNumbering True",
@@ -28,15 +28,15 @@ def _getRunLines(basePath: _tp.Optional[_pl.Path]) -> _tp.Sequence[str]:
     ]
     if not basePath:
         lines += [
-            'string PROJECT$ "C:\\Users\\epic.user\\EpicSimulation\\ddck"',
+            r'string PROJECT$ "C:\Users\epic.user\EpicSimulation\ddck"',
         ]
     lines += [
-        'string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
+        r'string trnsysExePath "C:\Trnsys18\Exe\TRNExe.exe"',
         'string scaling "False"',
     ]
     if not basePath:
         lines += [
-            'string projectPath "C:\\Users\\epic.user\\EpicSimulation"',
+            r'string projectPath "C:\Users\epic.user\EpicSimulation"',
         ]
     lines += [
         'string nameRef "DoublePipeDebug"',
@@ -44,11 +44,11 @@ def _getRunLines(basePath: _tp.Optional[_pl.Path]) -> _tp.Sequence[str]:
         "deck START 0",
         "deck STOP  8760",
         "deck dtSim 1",
-        "PROJECT$ generic\\head",
-        "PROJECT$ control\\hydraulic_control",
-        "PROJECT$ hydraulic\\hydraulic",
-        "PROJECT$ QSrc1\\QSrc",
-        "PROJECT$ generic\\end",
+        r"PROJECT$ generic\head",
+        r"PROJECT$ control\hydraulic_control",
+        r"PROJECT$ hydraulic\hydraulic",
+        r"PROJECT$ QSrc1\QSrc",
+        r"PROJECT$ generic\end",
     ]
     if basePath:
         lines += [
@@ -82,9 +82,9 @@ def _getProcessLines(basePath: _tp.Optional[_pl.Path]) -> _tp.Sequence[str]:
     ]
     if not basePath:
         lines += [
-            'string pathBase "C:\\Users\\epic.user\\EpicSimulation"',
+            r'string pathBase "C:\Users\epic.user\EpicSimulation"',
         ]
-    lines += ['string dllTrnsysPath "C:\\Trnsys18\\UserLib\\ReleaseDlls"', 'stringArray plotHourly "TInQSrc1"']
+    lines += [r'string dllTrnsysPath "C:\Trnsys18\UserLib\ReleaseDlls"', 'stringArray plotHourly "TInQSrc1"']
     if basePath:
         lines += [f"string pathBase {basePath}"]
     return lines
@@ -115,7 +115,7 @@ def _getInputs(
         "reduceCpu": 4,
     }
     if configType == "run":
-        inputs["PROJECT$"] = "C:\\Users\\epic.user\\EpicSimulation\\ddck"
+        inputs["PROJECT$"] = r"C:\Users\epic.user\EpicSimulation\ddck"
         inputs["addAutomaticEnergyBalance"] = True
         inputs["checkDeck"] = True
         inputs["doAutoUnitNumbering"] = True
@@ -124,12 +124,12 @@ def _getInputs(
         inputs["nameRef"] = "DoublePipeDebug"
         inputs["outputLevel"] = "INFO"
         inputs["parseFileCreated"] = True
-        inputs["pathToConnectionInfo"] = "C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json"
-        inputs["projectPath"] = "C:\\Users\\epic.user\\EpicSimulation"
+        inputs["pathToConnectionInfo"] = r"C:\Users\epic.user\EpicSimulation\DdckPlaceHolderValues.json"
+        inputs["projectPath"] = r"C:\Users\epic.user\EpicSimulation"
         inputs["runCases"] = True
         inputs["runType"] = "runFromConfig"
         inputs["scaling"] = "False"
-        inputs["trnsysExePath"] = "C:\\Trnsys18\\Exe\\TRNExe.exe"
+        inputs["trnsysExePath"] = r"C:\Trnsys18\Exe\TRNExe.exe"
         if basePath:
             inputs["PROJECT$"] = str(basePath / "ddck")
             inputs["pathToConnectionInfo"] = str(basePath / "DdckPlaceHolderValues.json")
@@ -139,14 +139,14 @@ def _getInputs(
         inputs["calculateHeatDemand"] = True
         inputs["cleanModeLatex"] = False
         inputs["createLatexPdf"] = True
-        inputs["dllTrnsysPath"] = "C:\\Trnsys18\\UserLib\\ReleaseDlls"
+        inputs["dllTrnsysPath"] = r"C:\Trnsys18\UserLib\ReleaseDlls"
         inputs["firstMonthUsed"] = 0
         inputs["forceProcess"] = True
         inputs["isTrnsys"] = True
         inputs["latexNames"] = "latexNames.json"
         inputs["numberOfYearsInHourlyFile"] = 1
         inputs["outputLevel"] = "DEBUG"
-        inputs["pathBase"] = "C:\\Users\\epic.user\\EpicSimulation"
+        inputs["pathBase"] = r"C:\Users\epic.user\EpicSimulation"
         inputs["plotHourly"] = [["TInQSrc1"]]
         inputs["processParallel"] = False
         inputs["processQvsT"] = False

--- a/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
+++ b/tests/pytrnsys/trnsys_util/testReadConfigTrnsys.py
@@ -6,25 +6,25 @@ import pytrnsys.trnsys_util.readConfigTrnsys as _rct
 _DATA_DIR_PATH = _pl.Path(__file__).parent / "data"
 
 
-def _getLines(_PATH=None, _without=False):
+def _getLines(path=None, without=False):
     _LINES = ['bool ignoreOnlinePlotter  True',
               'int reduceCpu  4',
               'bool parseFileCreated True',
               'bool runCases True',
               'bool checkDeck True',
               'string outputLevel "INFO"', ]
-    if not _without:
+    if not without:
         _LINES += ['string pathToConnectionInfo '
                    '"C:\\Users\\epic.user\\EpicSimulation\\DdckPlaceHolderValues.json"', ]  # this one
     _LINES += ['bool doAutoUnitNumbering True',
                'bool generateUnitTypesUsed True',
                'bool addAutomaticEnergyBalance True', ]
-    if not _without:
+    if not without:
         _LINES += ['string PROJECT$ '
                    '"C:\\Users\\epic.user\\EpicSimulation\\ddck"', ]
     _LINES += ['string trnsysExePath "C:\\Trnsys18\\Exe\\TRNExe.exe"',
                'string scaling "False"', ]
-    if not _without:
+    if not without:
         _LINES += ['string projectPath '
                    '"C:\\Users\\epic.user\\EpicSimulation"', ]
     _LINES += ['string nameRef "DoublePipeDebug"',
@@ -37,21 +37,21 @@ def _getLines(_PATH=None, _without=False):
                'PROJECT$ hydraulic\\hydraulic',
                'PROJECT$ QSrc1\\QSrc',
                'PROJECT$ generic\\end']
-    if _without:
+    if without:
         _LINES += ['string pathToConnectionInfo '
-                   f'{_PATH}\\DdckPlaceHolderValues.json',
+                   f'{path}\\DdckPlaceHolderValues.json',
                    'string PROJECT$ '
-                   f'{_PATH}\\ddck',
+                   f'{path}\\ddck',
                    'string projectPath '
-                   f'{_PATH}']
+                   f'{path}']
     return _LINES
 
 
 _ORIGINAL_LINES = _getLines()
-_LINES_WITHOUT = _getLines(_DATA_DIR_PATH, _without=True)
+_LINES_WITHOUT = _getLines(_DATA_DIR_PATH, without=True)
 
 
-def _getProcessLines(_PATH=None, _without=False):
+def _getProcessLines(path=None, without=False):
     _LINES = ['bool processParallel False',
               'bool processQvsT False',
               'bool cleanModeLatex False',
@@ -66,21 +66,21 @@ def _getProcessLines(_PATH=None, _without=False):
               'int firstMonthUsed 0',
               'int numberOfYearsInHourlyFile 1',
               'string latexNames "latexNames.json"', ]
-    if not _without:
+    if not without:
         _LINES += ['string pathBase "C:\\Users\\epic.user\\EpicSimulation"', ]
     _LINES += ['string dllTrnsysPath "C:\\Trnsys18\\UserLib\\ReleaseDlls"',
                'stringArray plotHourly "TInQSrc1"']
-    if _without:
+    if without:
         _LINES += ['string pathBase '
-                   f'{_DATA_DIR_PATH}']
+                   f'{path}']
     return _LINES
 
 
 _PROCESS_ORIGINAL_LINES = _getProcessLines()
-_PROCESS_LINES_WITHOUT = _getProcessLines(_PATH=_DATA_DIR_PATH, _without=True)
+_PROCESS_LINES_WITHOUT = _getProcessLines(path=_DATA_DIR_PATH, without=True)
 
 
-def _getInputs(_PATH=None, _without=False, configType='run'):
+def _getInputs(path=None, without=False, configType='run'):
     _inputs = {'calc': [],
                'calcCumSumHourly': [],
                'calcCumSumTimeStep': [],
@@ -113,10 +113,10 @@ def _getInputs(_PATH=None, _without=False, configType='run'):
         _inputs['runType'] = 'runFromConfig'
         _inputs['scaling'] = 'False'
         _inputs['trnsysExePath'] = 'C:\\Trnsys18\\Exe\\TRNExe.exe'
-        if _without:
-            _inputs['PROJECT$'] = f'{_DATA_DIR_PATH}\\ddck'
-            _inputs['pathToConnectionInfo'] = f'{_DATA_DIR_PATH}\\DdckPlaceHolderValues.json'
-            _inputs['projectPath'] = _pl.WindowsPath(f'{_DATA_DIR_PATH}')
+        if without:
+            _inputs['PROJECT$'] = f'{path}\\ddck'
+            _inputs['pathToConnectionInfo'] = f'{path}\\DdckPlaceHolderValues.json'
+            _inputs['projectPath'] = _pl.WindowsPath(f'{path}')
 
     elif configType == 'process':
         _inputs['calculateHeatDemand'] = True
@@ -136,16 +136,16 @@ def _getInputs(_PATH=None, _without=False, configType='run'):
         _inputs['reduceCpu'] = 1
         _inputs['setPrintDataForGle'] = True
         _inputs['yearReadedInMonthlyFile'] = -1
-        if _without:
-            _inputs['pathBase'] = _pl.WindowsPath(f'{_DATA_DIR_PATH}')
+        if without:
+            _inputs['pathBase'] = _pl.WindowsPath(f'{path}')
 
     return _inputs
 
 
 _ORIGINAL_INPUTS = _getInputs()
-_INPUTS_WITHOUT = _getInputs(_DATA_DIR_PATH, _without=True)
+_INPUTS_WITHOUT = _getInputs(_DATA_DIR_PATH, without=True)
 _INPUTS_PROCESS = _getInputs(configType='process')
-_INPUTS_PROCESS_WITHOUT = _getInputs(_DATA_DIR_PATH, configType='process', _without=True)
+_INPUTS_PROCESS_WITHOUT = _getInputs(_DATA_DIR_PATH, without=True, configType='process')
 
 
 class TestReadConfigTrnsys:


### PR DESCRIPTION
Tests now exist for absolute paths and providing no paths at all.
When no paths are provided, the current path is taken as the project path and the default folder structure is assumed:
e.g. "project_path\ddck"
